### PR TITLE
feat: Pass hit reslut to event

### DIFF
--- a/demo/src/index.tsx
+++ b/demo/src/index.tsx
@@ -1,5 +1,6 @@
 // @ts-ignore
 import * as OGL from 'ogl'
+import { Program } from 'ogl-typescript'
 import * as React from 'react'
 import { render } from 'react-dom'
 // @ts-ignore
@@ -13,7 +14,14 @@ const Box = (props: MeshProps) => {
   const [hovered, setHover] = React.useState(false)
   const [active, setActive] = React.useState(false)
 
-  useFrame(() => (mesh.current.rotation.x += 0.01))
+  const programRef = React.useRef<Program>();
+
+  let point = [0,0];
+
+  useFrame(() => {
+    mesh.current.rotation.x += 0.01;
+    programRef.current.uniforms.uPoint.value = point;
+  });
 
   return (
     <mesh
@@ -23,21 +31,26 @@ const Box = (props: MeshProps) => {
       onClick={() => setActive((value) => !value)}
       onPointerOver={() => setHover(true)}
       onPointerOut={() => setHover(false)}
+      onPointerMove={({ hit }) => hit && (point = hit.uv)}
     >
-      <box />
+      <box/>
       <program
+        ref={ programRef }
         vertex={`
           attribute vec3 position;
           attribute vec3 normal;
+          attribute vec2 uv;
 
           uniform mat4 modelViewMatrix;
           uniform mat4 projectionMatrix;
           uniform mat3 normalMatrix;
 
           varying vec3 vNormal;
+          varying vec2 vUv;
 
           void main() {
             vNormal = normalize(normalMatrix * normal);
+            vUv = uv;
             gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);
           }
         `}
@@ -45,17 +58,21 @@ const Box = (props: MeshProps) => {
           precision highp float;
 
           uniform vec3 uColor;
+          uniform vec2 uPoint;
+
           varying vec3 vNormal;
+          varying vec2 vUv;
 
           void main() {
             vec3 normal = normalize(vNormal);
             float lighting = dot(normal, normalize(vec3(10)));
 
-            gl_FragColor.rgb = uColor + lighting * 0.1;
+            gl_FragColor.rgb = vec3(vUv, 1.0) + lighting * 0.1;
+            gl_FragColor.rgb = mix (vec3(0.0), gl_FragColor.rgb, step(0.01, length(uPoint - vUv)));
             gl_FragColor.a = 1.0;
           }
         `}
-        uniforms={{ uColor: hovered ? hotpink : orange }}
+        uniforms={{ uColor: hovered ? hotpink : orange, uPoint: [0,0] }}
       />
     </mesh>
   )

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -49,7 +49,7 @@ export const createEvents = (state: RootState) => {
 
     // Get elements that intersect with our pointer
     state.raycaster.castMouse(state.camera, state.mouse)
-    const intersects: Instance[] = state.raycaster.intersectBounds(interactive)
+    const intersects: Instance[] = state.raycaster.intersectMeshes(interactive)
 
     // Used to discern between generic events and custom hover events.
     // We hijack the pointermove event to handle hover state
@@ -67,11 +67,11 @@ export const createEvents = (state: RootState) => {
         state.hovered.set(object.id, object)
 
         // Fire hover events
-        handlers.onPointerMove?.(event)
-        handlers.onPointerOver?.(event)
+        handlers.onPointerMove?.({ event, hit: object.hit })
+        handlers.onPointerOver?.({ event, hit: object.hit })
       } else {
         // Otherwise, fire its generic event
-        handlers[type]?.(event)
+        handlers[type]?.({ event, hit: object.hit })
       }
     })
 
@@ -85,7 +85,7 @@ export const createEvents = (state: RootState) => {
           state.hovered.delete(object.id)
 
           // Fire unhover event
-          if (handlers?.onPointerOut) handlers.onPointerOut(event)
+          if (handlers?.onPointerOut) handlers.onPointerOut({ event, hit: object.hit })
         }
       })
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type * as OGL from 'ogl-typescript'
+import { Vec2, Vec3 } from 'ogl-typescript'
 import type { MutableRefObject } from 'react'
 import { RENDER_MODES } from './constants'
 
@@ -57,16 +58,33 @@ export type Events = {
   onPointerMove: EventListener
 }
 
+export interface IHitResult {
+  localPoint: Vec3
+  point: Vec3
+  distance: number
+
+  faceNormal?: Vec3
+  localFaceNormal?: Vec3
+  localNormal?: Vec3
+  normal?: Vec3
+
+  uv?: Vec2
+}
+
+export interface IEventPair<T> {
+  event: T
+  hit?: IHitResult
+}
 /**
  * react-ogl event handlers.
  */
 export type EventHandlers = {
-  onClick?: (event: MouseEvent) => void
-  onPointerUp?: (event: PointerEvent) => void
-  onPointerDown?: (event: PointerEvent) => void
-  onPointerMove?: (event: PointerEvent) => void
-  onPointerOver?: (event: PointerEvent) => void
-  onPointerOut?: (event: PointerEvent) => void
+  onClick?: (event: IEventPair<MouseEvent>) => void
+  onPointerUp?: (event: IEventPair<PointerEvent>) => void
+  onPointerDown?: (event: IEventPair<PointerEvent>) => void
+  onPointerMove?: (event: IEventPair<PointerEvent>) => void
+  onPointerOver?: (event: IEventPair<PointerEvent>) => void
+  onPointerOut?: (event: IEventPair<PointerEvent>) => void
 }
 
 /**


### PR DESCRIPTION
Because events fired in object space, we can't use a UV asn World coords from event.

For resolve this rintime shoud instead of InterectBounds use a IntersetectMeshes and include a mesh to event data.

See: 
https://github.com/oframe/ogl/blob/master/src/extras/Raycast.js#L129
https://github.com/oframe/ogl/blob/master/src/extras/Raycast.js#L232

We can use a flag for selecting which is mode should be used for tracking events, because not always required a strict recognition, but i not shure how this can be selected object-specifically in event phase.