### PR TITLE
fix uniform update

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -73,7 +73,7 @@ export const applyProps = (instance: Instance, newProps: InstanceProps, oldProps
       } else {
         // Allow shorthand values for uniforms
         if (key === 'uniforms') {
-          value = Object.entries(value).reduce((acc, [uniform, entry]) => {
+          Object.entries(value).forEach(([uniform, entry]) => {
             // Handle uniforms which don't have a value key set
             if (entry.value === undefined) {
               let value: any
@@ -92,10 +92,10 @@ export const applyProps = (instance: Instance, newProps: InstanceProps, oldProps
               entry = { value }
             }
 
-            acc[uniform] = entry
-
-            return acc
-          }, {})
+            root[key][uniform] = entry
+          })
+          // we apply uniforms directly to object as patch, not need apply value
+          return
         }
 
         // Mutate the property directly

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,7 +75,7 @@ export const applyProps = (instance: Instance, newProps: InstanceProps, oldProps
         if (key === 'uniforms') {
           Object.entries(value).forEach(([uniform, entry]) => {
             // Handle uniforms which don't have a value key set
-            if (entry.value === undefined) {
+            if (entry?.value === undefined) {
               let value: any
 
               if (typeof entry === 'string') {

--- a/tests/__snapshots__/utils.test.tsx.snap
+++ b/tests/__snapshots__/utils.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`applyProps should diff & merge uniforms 1`] = `
+Object {
+  "a": Object {
+    "value": 0,
+  },
+  "b": Object {
+    "value": 1,
+  },
+  "c": Object {
+    "value": 2,
+  },
+}
+`;

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -1,0 +1,26 @@
+// @ts-ignore
+import * as OGL from 'ogl'
+import { applyProps } from '../src'
+
+describe('applyProps', () => {
+  it('should diff & merge uniforms', async () => {
+    const canvas = document.createElement('canvas')
+    const gl = canvas.getContext('webgl2')
+    const program = new OGL.Program(gl, {
+      vertex: '',
+      fragment: '',
+      uniforms: {},
+    })
+
+    applyProps(program, {
+      uniforms: {
+        a: 0,
+        b: 1,
+        c: null,
+      },
+    })
+    applyProps(program, { uniforms: { c: 2 } })
+
+    expect(program.uniforms).toMatchSnapshot()
+  })
+})


### PR DESCRIPTION
Fix for #8
Fix apply a uniforms without assigning uniform property, only update known values in one.
Generic problem: uniform can already have applied value from base class or has external setter that can change value.
We shouldn't reset already defined uniforms, we should merge from props and override.

Should be tested!