### PR TITLE
fix: not change subscribed reference

### DIFF
--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -138,7 +138,7 @@ export const createInternals = (canvas: HTMLCanvasElement, props: RenderProps): 
 
   // Init rendering internals for useFrame, keep track of subscriptions
   let priority = 0
-  let subscribed = []
+  const subscribed = []
 
   // Subscribe/unsubscribe elements to the render loop
   const subscribe = (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => {
@@ -151,7 +151,9 @@ export const createInternals = (canvas: HTMLCanvasElement, props: RenderProps): 
 
   const unsubscribe = (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => {
     // Unsubscribe callback
-    subscribed = subscribed.filter((entry) => entry !== refCallback)
+    const index = subscribed.indexOf(refCallback);
+
+    if(index !== -1) subscribed.splice(index, 0);
 
     // Disable manual rendering if renderPriority is positive
     if (renderPriority) priority -= 1

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -153,7 +153,7 @@ export const createInternals = (canvas: HTMLCanvasElement, props: RenderProps): 
     // Unsubscribe callback
     const index = subscribed.indexOf(refCallback);
 
-    if(index !== -1) subscribed.splice(index, 0);
+    if (index !== -1) subscribed.splice(index, 0);
 
     // Disable manual rendering if renderPriority is positive
     if (renderPriority) priority -= 1


### PR DESCRIPTION
State MUST store actual reference to subscribed, but `unsubscribe` produce new Array which will unmatch with same field in state.

I use custom render loop and for me this is critical bug.
I can't use boxed loop because it use `requestAnimationFrame` from window, that not working in XR mode (XRSession has own requestAnimationFrame that needs to use instead of window.requestAnimationFrame)

```
	const animate = (time?: number) => {
		state.animation = renderer.requestAnimationFrame(animate);

		// update OGL useFrame
		subscribed.forEach((ref: any) => ref.current?.(state, time));

		// Render to screen
		renderer.render({ scene, camera, frustumCull: false } as any);
	};

	state.animation = renderer.requestAnimationFrame(animate);
```