### PR TITLE
feat(core): pass context to elements with `gl` prop

### DIFF
--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -17,7 +17,11 @@ export const extend = (objects: Catalogue) =>
 /**
  * Creates an OGL element from a React node.
  */
-export const createInstance = (type: string, { object, args, ...props }: InstanceProps, root: RootState) => {
+export const createInstance = (
+  type: string,
+  { object, args, gl: passGL, ...props }: InstanceProps,
+  root: RootState,
+) => {
   // Convert lowercase primitive to PascalCase
   const name = toPascalCase(type)
 
@@ -32,7 +36,10 @@ export const createInstance = (type: string, { object, args, ...props }: Instanc
 
   // Pass internal state to elements which depend on it.
   // This lets them be immutable upon creation and use props
-  if (!object && GL_ELEMENTS.some((elem) => Object.prototype.isPrototypeOf.call(elem, target) || elem === target)) {
+  if (
+    !object &&
+    (passGL || GL_ELEMENTS.some((elem) => Object.prototype.isPrototypeOf.call(elem, target) || elem === target))
+  ) {
     // Checks whether arg is an instance of a GL context
     const isGL = (arg: any) => arg instanceof WebGL2RenderingContext || arg instanceof WebGLRenderingContext
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -156,9 +156,7 @@ export type RenderProps = {
 }
 
 /**
- *
  * OGL / JSX types
- *
  */
 
 export interface NodeProps<T> {
@@ -169,6 +167,8 @@ export interface NodeProps<T> {
   children?: React.ReactNode
   ref?: React.Ref<React.ReactNode | {}>
   key?: React.Key
+  /* Whether to implicitly pass a WebGL2RenderingContext to args. Default is `true` for OGL built-in classes. */
+  gl?: boolean
 }
 
 export type Node<T, P> = Overwrite<Partial<T>, NodeProps<P>>


### PR DESCRIPTION
Implements #15 by passing the webgl context to elements who specify a `gl` prop.

```jsx
<customElement gl />
// <customElement gl={true} />
```

This can be done automatically for custom elements by appending to `GL_ELEMENTS`.