### PR TITLE
refactor(core): attach on mount, correctly handle fiber handoff

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -28,6 +28,27 @@ export const filterKeys = (obj: any, prune = false, ...keys: string[]) => {
 }
 
 /**
+ * Attaches an instance to a parent via its `attach` prop.
+ */
+export const attach = (parent: Instance, child: Instance) => {
+  if (!child.attach) return
+
+  parent[child.attach] = child
+  parent.__attached = parent.__attached || {}
+  parent.__attached[child.attach] = child
+}
+
+/**
+ * Removes an instance from a parent via its `attach` prop.
+ */
+export const detach = (parent: Instance, child: Instance) => {
+  if (!parent?.__attached?.[child.attach]) return
+
+  delete parent.__attached[child.attach]
+  parent[child.attach] = null
+}
+
+/**
  * Safely mutates an OGL element, respecting special JSX syntax.
  */
 export const applyProps = (instance: Instance, newProps: InstanceProps, oldProps: InstanceProps = {}) => {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -169,4 +169,32 @@ describe('renderer', () => {
     expect(bind).toBe(true)
     expect(unbind).toBe(true)
   })
+
+  it('will create an identical instance when reconstructing', async () => {
+    let state: RootState = null!
+
+    const Test = ({ n }: { n: number }) => (
+      // @ts-ignore args isn't a valid prop but changing it will swap
+      <transform args={[n]}>
+        <transform attach="test" />
+        <transform visible={false} />
+      </transform>
+    )
+
+    await reconciler.act(async () => {
+      state = render(<Test n={1} />)
+    })
+
+    const [oldInstance] = state.scene.children
+    oldInstance.original = true
+
+    await reconciler.act(async () => {
+      state = render(<Test n={2} />)
+    })
+
+    const [newInstance] = state.scene.children
+    expect(newInstance.original).not.toBe(true) // Created a new instance
+    expect(newInstance.children[0].visible).toBe(false) // Preserves scene hierarchy
+    expect(newInstance.test.visible).toBe(true) // Preserves scene hierarchy through attach
+  })
 })


### PR DESCRIPTION
Fixes a potential issue with attach and suspense by relegating the actual attachment until mount, where scene children are finalized.

Also cleans up internal react fiber handoff when swapping, creating, and inspecting instances in dev tools. Hopefully, this is the culprit of #4.