### PR TITLE
feat(core): customize gl behavior via extend

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -45,6 +45,7 @@
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/ban-ts-comment": "off",
     "@typescript-eslint/no-namespace": "off",
-    "@typescript-eslint/no-extra-semi": "off"
+    "@typescript-eslint/no-extra-semi": "off",
+    "@typescript-eslint/no-inferrable-types": "warn"
   }
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,3 @@
-import * as OGL from 'ogl'
-
 /**
  * react-ogl's virtual pointer events.
  */
@@ -10,27 +8,6 @@ export const POINTER_EVENTS = [
   'onPointerMove',
   'onPointerOver',
   'onPointerOut',
-] as const
-
-/**
- * OGL elements which must accept `gl` via constructor args.
- */
-export const GL_ELEMENTS = [
-  // Core
-  OGL.Camera,
-  OGL.Geometry,
-  OGL.Mesh,
-  OGL.Program,
-  OGL.RenderTarget,
-  OGL.Texture,
-
-  // Extras
-  OGL.Flowmap,
-  OGL.GPGPU,
-  OGL.NormalProgram,
-  OGL.Polyline,
-  OGL.Post,
-  OGL.Shadow,
 ] as const
 
 /**

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -31,7 +31,7 @@ const catalogueGL: any[] = [
  * Extends the OGL namespace, accepting an object of keys pointing to external classes.
  * `passGL` will flag the element to receive a `WebGLRenderingContext` on creation.
  */
-export const extend = (objects: Catalogue, passGL: boolean = false) => {
+export const extend = (objects: Catalogue, passGL = false) => {
   for (const key in objects) {
     const value = objects[key]
     catalogue[key] = value

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -2,17 +2,41 @@ import Reconciler from 'react-reconciler'
 import * as OGL from 'ogl'
 import * as React from 'react'
 import { toPascalCase, applyProps, attach, detach, filterKeys } from './utils'
-import { GL_ELEMENTS, RESERVED_PROPS } from './constants'
+import { RESERVED_PROPS } from './constants'
 import { Catalogue, Instance, InstanceProps, RootState } from './types'
 
 // Custom objects that extend the OGL namespace
 const catalogue: Catalogue = {}
 
+// Effectful catalogue elements that require a `WebGLRenderingContext`.
+const catalogueGL: Catalogue = {
+  Camera: OGL.Camera,
+  Geometry: OGL.Geometry,
+  Mesh: OGL.Mesh,
+  Program: OGL.Program,
+  RenderTarget: OGL.RenderTarget,
+  Texture: OGL.Texture,
+
+  // Extras
+  Flowmap: OGL.Flowmap,
+  GPGPU: OGL.GPGPU,
+  NormalProgram: OGL.NormalProgram,
+  Polyline: OGL.Polyline,
+  Post: OGL.Post,
+  Shadow: OGL.Shadow,
+}
+
 /**
  * Extends the OGL namespace, accepting an object of keys pointing to external classes.
+ * `passGL` will flag the element to receive a `WebGLRenderingContext` on creation.
  */
-export const extend = (objects: Catalogue) =>
-  Object.entries(objects).forEach(([key, value]) => (catalogue[key] = value))
+export const extend = (objects: Catalogue, passGL: boolean = false) => {
+  for (const key in objects) {
+    const value = objects[key]
+    catalogue[key] = value
+    if (passGL) catalogueGL[key] = value
+  }
+}
 
 /**
  * Creates an OGL element from a React node.
@@ -32,8 +56,8 @@ export const createInstance = (type: string, { object, args, ...props }: Instanc
 
   // Pass internal state to elements which depend on it.
   // This lets them be immutable upon creation and use props
-  const isGLInstance = GL_ELEMENTS.some((elem) => Object.prototype.isPrototypeOf.call(elem, target) || elem === target)
-  if (!object && isGLInstance) {
+  const passGL = !object && catalogueGL[name]
+  if (passGL) {
     // Checks whether arg is an instance of a GL context
     const isGL = (arg: any) => arg instanceof WebGL2RenderingContext || arg instanceof WebGLRenderingContext
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -9,22 +9,23 @@ import { Catalogue, Instance, InstanceProps, RootState } from './types'
 const catalogue: Catalogue = {}
 
 // Effectful catalogue elements that require a `WebGLRenderingContext`.
-const catalogueGL: Catalogue = {
-  Camera: OGL.Camera,
-  Geometry: OGL.Geometry,
-  Mesh: OGL.Mesh,
-  Program: OGL.Program,
-  RenderTarget: OGL.RenderTarget,
-  Texture: OGL.Texture,
+const catalogueGL: any[] = [
+  // Core
+  OGL.Camera,
+  OGL.Geometry,
+  OGL.Mesh,
+  OGL.Program,
+  OGL.RenderTarget,
+  OGL.Texture,
 
   // Extras
-  Flowmap: OGL.Flowmap,
-  GPGPU: OGL.GPGPU,
-  NormalProgram: OGL.NormalProgram,
-  Polyline: OGL.Polyline,
-  Post: OGL.Post,
-  Shadow: OGL.Shadow,
-}
+  OGL.Flowmap,
+  OGL.GPGPU,
+  OGL.NormalProgram,
+  OGL.Polyline,
+  OGL.Post,
+  OGL.Shadow,
+]
 
 /**
  * Extends the OGL namespace, accepting an object of keys pointing to external classes.
@@ -34,7 +35,7 @@ export const extend = (objects: Catalogue, passGL: boolean = false) => {
   for (const key in objects) {
     const value = objects[key]
     catalogue[key] = value
-    if (passGL) catalogueGL[key] = value
+    if (passGL) catalogueGL.push(value)
   }
 }
 
@@ -56,8 +57,10 @@ export const createInstance = (type: string, { object, args, ...props }: Instanc
 
   // Pass internal state to elements which depend on it.
   // This lets them be immutable upon creation and use props
-  const passGL = !object && catalogueGL[name]
-  if (passGL) {
+  const isGLInstance = Object.values(catalogueGL).some(
+    (elem) => Object.prototype.isPrototypeOf.call(elem, target) || elem === target,
+  )
+  if (!object && isGLInstance) {
     // Checks whether arg is an instance of a GL context
     const isGL = (arg: any) => arg instanceof WebGL2RenderingContext || arg instanceof WebGLRenderingContext
 


### PR DESCRIPTION
Implements #15 by accepting a `passGL` argument in `extend` which passes the active gl context automatically to the element in construction. Importantly, this will affect all elements passed in the call to `extend` or any elements who extend them. Passing gl as an arg to these elements will still work as before, however, it is unneeded.

```js
// Marks both classes as effectful and will receive an effect
extend({ CustomClass1, CustomClass2 }, true)
```
```diff
- const gl = useOGL()
- <customClass1 args={[gl]} prop={value} />
- <customClass2 args={[gl]} prop={value} />

+ <customClass1 prop={value} />
+ <customClass2 prop={value} />
```

This is enabled for core classes to let users use props instead of args for common classes like meshes, materials, geometry, and so on.

```js
<program vertex="" fragment="" />
```