### PR TITLE
feat(core): expanded attach

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -32,17 +32,18 @@ export type ObjectMap = {
  */
 export type Catalogue = { [key: string]: any }
 
+export type Attach = string | ((parent: Instance, self: Instance) => () => void)
+
 /**
  * Base OGL React instance.
  */
 export type BaseInstance = Omit<OGL.Transform, 'children' | 'attach'> & {
   isPrimitive?: boolean
   __handlers?: EventHandlers
-  __attached?: Record<string, BaseInstance>
+  __attached?: BaseInstance[]
+  __previousAttach?: any
   children: Instance[]
-  attach?: string
-  remove?(): void
-  dispose?(): void
+  attach?: Attach
 }
 
 /**
@@ -60,7 +61,7 @@ export type InstanceProps = {
   object?: object
   visible?: boolean
   dispose?: null
-  attach?: string
+  attach?: Attach
 }
 
 /**
@@ -176,7 +177,7 @@ export type RenderProps = {
 
 export interface NodeProps<T> {
   /** Attaches this class onto the parent under the given name and nulls it on unmount */
-  attach?: string
+  attach?: Attach
   /** Constructor arguments */
   args?: Filter<Args<T>, OGL.OGLRenderingContext>
   children?: React.ReactNode

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -55,6 +55,35 @@ describe('renderer', () => {
     expect(Object.keys(element.geometry.attributes)).toStrictEqual(['test'])
   })
 
+  it('should handle attach', async () => {
+    let state: RootState
+
+    await reconciler.act(async () => {
+      state = render(
+        <>
+          <mesh>
+            <geometry />
+            <normalProgram attach="program" />
+          </mesh>
+          <mesh>
+            <geometry />
+            <normalProgram
+              attach={(parent, self) => {
+                parent.program = self
+                return () => (parent.program = undefined)
+              }}
+            />
+          </mesh>
+        </>,
+      )
+    })
+
+    const [element1, element2] = state.scene.children
+
+    expect(element1.program).not.toBe(undefined)
+    expect(element2.program).not.toBe(undefined)
+  })
+
   it('should pass gl to args', async () => {
     let crashed = false
 


### PR DESCRIPTION
Expands the `attach` prop by accepting an attach function in addition to a string. This is 1-1 with [R3F v8's unified attach API](https://docs.pmnd.rs/react-three-fiber/tutorials/v8-migration-guide#unified-attach-api).

```js
// will attach to parent.target
<parent>
  <child attach="target" />
</parent>

// will attach to parent.target.subtarget
<parent>
  <child attach="target-subtarget" />
</parent>

// will attach to parent.target[0] and parent.target[1], creates an array if parent.target is undefined
// useful for attaching multiple elements to an array
<parent>
  <child attach="target-0" />
  <child attach="target-1" />
</parent>

// will call child.setParent on mount and child.removeChild unmount
<parent>
  <child
    attach={(parent, self) => {
      self.setParent(parent)
      // remove on unmount
      return () => parent.removeChild(self)
    }}
  />
</parent>
```