### PR TITLE
fix(native): prepare ogl context, don't overwrite renderer.render

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "react-native": "^0.67.1",
     "react-test-renderer": "^17.0.2",
     "rimraf": "^3.0.2",
-    "rollup-include-all": "^1.0.0",
+    "rollup-include-all": "^1.0.1",
     "typescript": "^4.5.5",
     "vite": "^2.9.9"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6445,10 +6445,10 @@ rimraf@~2.6.2:
   dependencies:
     glob "^7.1.3"
 
-rollup-include-all@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/rollup-include-all/-/rollup-include-all-1.0.0.tgz#a9d72fda8c2c567cde6527df4d35477d769dadd8"
-  integrity sha512-at+wdhq9xNadCEbQsq1/PcUMXyg0QQ9TbttjS6PFa8mKQ+8w3OEXfz1b5xP9eTxNqUTnDpPcwEMWnfSRjc7BDw==
+rollup-include-all@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/rollup-include-all/-/rollup-include-all-1.0.1.tgz#e21119cf9541df12b4aeede68f5c19e07bf09e71"
+  integrity sha512-R7E+kwROeqHVT0niZueFJUu0u/NcmN+f3zPxfbcQ3lDXGiqBKrn78rNiy7l4mFwtIa0ZoA0xCkwHRtvoWeNWWQ==
 
 rollup@^2.59.0:
   version "2.75.3"


### PR DESCRIPTION
Updates `rollup-include-all` to exclude file exts in name for native resolution, preps the gl context to match OGL's internals, and preserves parameters passed to renderer.render in native contexts.