### PR TITLE
feat(core): add xr manager, render mode switching

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "dependencies": {
     "@expo/browser-polyfill": "^1.0.0",
     "@types/react-reconciler": "^0.26.4",
+    "@types/webxr": "^0.4.0",
     "ogl-typescript": "^0.1.40",
     "react-reconciler": "^0.26.2",
     "react-use-measure": "^2.1.1",

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -125,18 +125,18 @@ export const render = (
     config.onCreated?.(state)
 
     // Toggle rendering modes
-    let frame: number
-    const animate = (time?: number) => {
+    let nextFrame: number
+    const animate = (time = 0, frame?: XRFrame) => {
       // Toggle XR rendering
       const state = store.getState()
       const mode = state.xr.session ?? window
 
       // Cancel animation if frameloop is set, otherwise keep looping
-      if (state.frameloop === 'never') return mode.cancelAnimationFrame(frame)
-      frame = mode.requestAnimationFrame(animate)
+      if (state.frameloop === 'never') return mode.cancelAnimationFrame(nextFrame)
+      nextFrame = mode.requestAnimationFrame(animate)
 
       // Call subscribed elements
-      for (const ref of state.subscribed) ref.current?.(state, time)
+      for (const ref of state.subscribed) ref.current?.(state, time, frame)
 
       // If rendering manually, skip render
       if (state.priority) return

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,11 +1,11 @@
 import * as OGL from 'ogl'
 import * as React from 'react'
 import { Fiber } from 'react-reconciler'
-import create, { SetState } from 'zustand'
+import create, { GetState, SetState } from 'zustand'
 import { reconciler } from './reconciler'
 import { RENDER_MODES } from './constants'
 import { OGLContext } from './hooks'
-import { Instance, InstanceProps, RenderProps, Root, RootState, RootStore, Subscription } from './types'
+import { Instance, InstanceProps, RenderProps, Root, RootState, RootStore, Subscription, XRManager } from './types'
 import { applyProps, calculateDpr } from './utils'
 
 // Store roots here since we can render to multiple targets
@@ -19,90 +19,103 @@ export const render = (
   target: HTMLCanvasElement,
   {
     mode = 'blocking',
+    dpr = [1, 2],
     size = { width: target.parentElement?.clientWidth ?? 0, height: target.parentElement?.clientHeight ?? 0 },
+    frameloop = 'always',
+    orthographic = false,
+    events,
     ...config
   }: RenderProps = {},
 ) => {
   // Check for existing root, create on first run
   let root = roots.get(target)
   if (!root) {
-    // Create renderer
-    const renderer =
-      config.renderer instanceof OGL.Renderer
-        ? config.renderer
-        : typeof config.renderer === 'function'
-        ? config.renderer(target)
-        : new OGL.Renderer({
-            antialias: true,
-            powerPreference: 'high-performance',
-            ...(config.renderer as any),
-            canvas: target,
-          })
-    if (config.renderer && typeof config.renderer !== 'function')
-      applyProps(renderer as unknown as Instance, config.renderer as InstanceProps)
-
-    renderer.dpr = calculateDpr(config.dpr ?? [1, 2])
-
-    const gl = renderer.gl
-    gl.clearColor(1, 1, 1, 0)
-
-    // Create or accept camera, apply props
-    const camera =
-      config.camera instanceof OGL.Camera
-        ? config.camera
-        : new OGL.Camera(gl, { fov: 75, near: 1, far: 1000, ...(config.camera as any) })
-    camera.position.z = 5
-    if (config.camera) applyProps(camera, config.camera as InstanceProps)
-
-    // Create scene
-    const scene = new OGL.Transform()
-
-    // Init rendering internals for useFrame, keep track of subscriptions
-    let priority = 0
-    const subscribed = []
-
-    // Subscribe/unsubscribe elements to the render loop
-    const subscribe = (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => {
-      // Subscribe callback
-      subscribed.push(refCallback)
-
-      // Enable manual rendering if renderPriority is positive
-      if (renderPriority) priority += 1
-    }
-
-    const unsubscribe = (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => {
-      // Unsubscribe callback
-      const index = subscribed.indexOf(refCallback)
-
-      if (index !== -1) subscribed.splice(index, 0)
-
-      // Disable manual rendering if renderPriority is positive
-      if (renderPriority) priority -= 1
-    }
-
-    // Init event state
-    const mouse = new OGL.Vec2()
-    const raycaster = new OGL.Raycast(gl)
-    const hovered = new Map()
-
     // Create root store
-    const store = create((set: SetState<RootState>, get: SetState<RootState>) => ({
-      size,
-      renderer,
-      gl,
-      camera,
-      scene,
-      priority,
-      subscribed,
-      subscribe,
-      unsubscribe,
-      mouse,
-      raycaster,
-      hovered,
-      events: config.events,
-      set,
-      get,
-    })) as RootStore
+    const store = create((set: SetState<RootState>, get: GetState<RootState>) => {
+      // Create renderer
+      const renderer =
+        config.renderer instanceof OGL.Renderer
+          ? config.renderer
+          : typeof config.renderer === 'function'
+          ? config.renderer(target)
+          : new OGL.Renderer({
+              antialias: true,
+              powerPreference: 'high-performance',
+              ...(config.renderer as any),
+              canvas: target,
+            })
+      if (config.renderer && typeof config.renderer !== 'function')
+        applyProps(renderer as unknown as Instance, config.renderer as InstanceProps)
+
+      renderer.dpr = calculateDpr(dpr)
+
+      const gl = renderer.gl
+      gl.clearColor(1, 1, 1, 0)
+
+      // Create or accept camera, apply props
+      const camera =
+        config.camera instanceof OGL.Camera
+          ? config.camera
+          : new OGL.Camera(gl, { fov: 75, near: 1, far: 1000, ...(config.camera as any) })
+      camera.position.z = 5
+      if (config.camera) applyProps(camera, config.camera as InstanceProps)
+
+      // Create scene
+      const scene = new OGL.Transform()
+
+      // Init rendering internals for useFrame, keep track of subscriptions
+      let priority = 0
+      const subscribed = []
+
+      // Subscribe/unsubscribe elements to the render loop
+      const subscribe = (refCallback: React.MutableRefObject<Subscription>, renderPriority = 0) => {
+        // Subscribe callback
+        subscribed.push(refCallback)
+
+        // Enable manual rendering if renderPriority is positive
+        priority += renderPriority
+      }
+
+      const unsubscribe = (refCallback: React.MutableRefObject<Subscription>, renderPriority = 0) => {
+        // Unsubscribe callback
+        const index = subscribed.indexOf(refCallback)
+        if (index !== -1) subscribed.splice(index, 0)
+
+        // Disable manual rendering if renderPriority is positive
+        priority -= renderPriority
+      }
+
+      const xr: XRManager = {
+        session: null,
+        setSession(session) {
+          set((state) => ({ xr: { ...state.xr, session } }))
+        },
+        connect(session) {
+          xr.setSession(session)
+        },
+        disconnect() {
+          xr.setSession(null)
+        },
+      }
+
+      return {
+        size,
+        xr,
+        renderer,
+        frameloop,
+        orthographic,
+        gl,
+        camera,
+        scene,
+        priority,
+        subscribed,
+        subscribe,
+        unsubscribe,
+        events,
+        set,
+        get,
+      }
+    }) as RootStore
 
     // Bind events
     const state = store.getState()
@@ -111,11 +124,16 @@ export const render = (
     // Handle callback
     config.onCreated?.(state)
 
-    // Animate
+    // Toggle rendering modes
+    let frame: number
     const animate = (time?: number) => {
+      // Toggle XR rendering
+      const state = store.getState()
+      const mode = state.xr.session ?? window
+
       // Cancel animation if frameloop is set, otherwise keep looping
-      if (state.frameloop === 'never') return cancelAnimationFrame(state.animation)
-      state.animation = requestAnimationFrame(animate)
+      if (state.frameloop === 'never') return mode.cancelAnimationFrame(frame)
+      frame = mode.requestAnimationFrame(animate)
 
       // Call subscribed elements
       for (const ref of state.subscribed) ref.current?.(state, time)
@@ -131,12 +149,10 @@ export const render = (
     // Handle resize
     const onResize = (state: RootState) => {
       const { width, height } = state.size
-      if (state.renderer.width !== width || state.renderer.height !== height) {
-        // Set dpr, handle resize
-        state.renderer.setSize(width, height)
+      const projection = state.orthographic ? 'orthographic' : 'perspective'
 
-        // Update projection
-        const projection = state.orthographic ? 'orthographic' : 'perspective'
+      if (state.renderer.width !== width || state.renderer.height !== height || state.camera.type !== projection) {
+        state.renderer.setSize(width, height)
         state.camera[projection]({ aspect: width / height })
       }
     }
@@ -150,6 +166,12 @@ export const render = (
     root = { fiber, store }
     roots.set(target, root)
   }
+
+  // Update reactive props
+  const state = root.store.getState()
+  if (state.size.width !== size.width || state.size.height !== size.height) state.set(() => ({ size }))
+  if (state.frameloop !== frameloop) state.set(() => ({ frameloop }))
+  if (state.orthographic !== orthographic) state.set(() => ({ orthographic }))
 
   // Update fiber
   reconciler.updateContainer(
@@ -177,7 +199,7 @@ export const unmountComponentAtNode = (target: HTMLCanvasElement) => {
     const state = root.store.getState()
 
     // Cancel animation
-    if (state.animation) cancelAnimationFrame(state.animation)
+    state.set(() => ({ frameloop: 'never' }))
 
     // Unbind events
     if (state.events?.disconnect) state.events.disconnect(target, state)

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,7 +140,7 @@ export type Frameloop = 'always' | 'never'
 /**
  * useFrame subscription.
  */
-export type Subscription = (state: RootState, time: number) => any
+export type Subscription = (state: RootState, time: number, frame?: XRFrame) => any
 
 /**
  * react-ogl internal state.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
+/// <reference types="webxr" />
 import type * as OGL from 'ogl-typescript'
 import type { MutableRefObject } from 'react'
-import type { SetState, UseBoundStore, StoreApi } from 'zustand'
+import type { SetState, GetState, UseBoundStore, StoreApi } from 'zustand'
 import { COLORS, RENDER_MODES } from './constants'
 
 // Util funcs
@@ -112,6 +113,13 @@ export interface Root {
   unmount: () => void
 }
 
+export interface XRManager {
+  session: XRSession | null
+  setSession(session: XRSession | null): void
+  connect(session: XRSession): void
+  disconnect(): void
+}
+
 /**
  * react-ogl event manager.
  */
@@ -139,8 +147,9 @@ export type Subscription = (state: RootState, time: number) => any
  */
 export interface RootState {
   set: SetState<RootState>
-  get: SetState<RootState>
+  get: GetState<RootState>
   size: Size
+  xr: XRManager
   orthographic: boolean
   frameloop: Frameloop
   renderer: OGL.Renderer
@@ -151,7 +160,6 @@ export interface RootState {
   subscribed: React.MutableRefObject<Subscription>[]
   subscribe: (refCallback: MutableRefObject<Subscription>, renderPriority?: number) => void
   unsubscribe: (refCallback: MutableRefObject<Subscription>, renderPriority?: number) => void
-  animation?: number
   events?: EventManager
   mouse?: OGL.Vec2
   raycaster?: OGL.Raycast

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -205,6 +205,11 @@ export const buildGraph = (object: OGL.Transform) => {
  * Creates event handlers, returning an event handler method.
  */
 export const createEvents = (state: RootState) => {
+  // Init event state
+  state.mouse = new OGL.Vec2()
+  state.raycaster = new OGL.Raycast(state.gl)
+  state.hovered = new Map()
+
   const handleEvent = (event: PointerEvent, type: keyof EventHandlers) => {
     // Convert mouse coordinates
     state.mouse.x = (event.offsetX / state.renderer.width) * 2 - 1

--- a/yarn.lock
+++ b/yarn.lock
@@ -1692,6 +1692,11 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
+"@types/webxr@^0.4.0":
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.4.0.tgz#ad06c96a324293e0d5175d13dd5ded5931f90ba3"
+  integrity sha512-LQvrACV3Pj17GpkwHwXuTd733gfY+D7b9mKdrTmLdO7vo7P/o6209Qqtk63y/FCv/lspdmi0pWz6Qe/ull9kQg==
+
 "@types/yargs-parser@*":
   version "20.2.1"
   resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"


### PR DESCRIPTION
Adds support for WebXR rendering via an XRManager:

```ts
XRManager {
  session: XRSession | null
  setSession(session: XRSession | null): void
  connect(session: XRSession): void
  disconnect(): void
}

//

const renderer = useOGL(state => state.renderer)
const xr = useOGL(state => state.xr)

useEffect(() => {
  let mounted = true

  (async () => {
    const session = await navigator.xr.requestSession('immersive-vr', {
      optionalFeatures: ['local-floor', 'bounded-floor', 'hand-tracking'],
    })
    session.updateRenderState({ baseLayer: new XRWebGLLayer(session, renderer.gl) })

    if (!mounted) return session.end()
    else xr.connect(session)
  })()

  return () => {
    mounted = false
    xr.disconnect()
  }
}, [renderer, xr])
```

This will augment useFrame subscriptions to access an `XRFrame` while in a session:

```ts
useFrame((state: RootState, time: number, frame?: XRFrame) => {
  // ...
})
```