### PR TITLE
fix(core): prepare portal targets

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,10 +1,10 @@
 import * as OGL from 'ogl'
 import * as React from 'react'
-import { Fiber } from 'react-reconciler'
+import { Fiber, ReactPortal } from 'react-reconciler'
 import create, { GetState, SetState } from 'zustand'
 import { reconciler } from './reconciler'
 import { RENDER_MODES } from './constants'
-import { OGLContext } from './hooks'
+import { OGLContext, useOGL } from './hooks'
 import { Instance, InstanceProps, RenderProps, Root, RootState, RootStore, Subscription, XRManager } from './types'
 import { applyProps, calculateDpr } from './utils'
 
@@ -214,8 +214,16 @@ export const createRoot = (target: HTMLCanvasElement, config?: RenderProps): Roo
   unmount: () => unmountComponentAtNode(target),
 })
 
+// Prepares portal target
+function PortalRoot({ children, target }: { children: React.ReactElement; target: OGL.Transform }) {
+  const gl = useOGL((state) => state.gl)
+  if (!target.gl) target.gl = gl
+  return children
+}
+
 /**
  * Portals into a remote OGL element.
  */
-export const createPortal = (children: React.ReactNode, target: OGL.Transform): React.ReactNode =>
-  reconciler.createPortal(children, target, null, null)
+export const createPortal = (children: React.ReactElement, target: OGL.Transform): ReactPortal => {
+  return reconciler.createPortal(<PortalRoot target={target}>{children}</PortalRoot>, target, null, null)
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -39,7 +39,9 @@ export type Attach = string | ((parent: Instance, self: Instance) => () => void)
 /**
  * Base OGL React instance.
  */
-export type BaseInstance = Omit<OGL.Transform, 'children' | 'attach'> & {
+export type BaseInstance = Omit<OGL.Transform, 'children' | 'attach' | 'parent'> & {
+  gl: OGL.OGLRenderingContext
+  parent: BaseInstance | null
   isPrimitive?: boolean
   __handlers?: EventHandlers
   __attached?: BaseInstance[]

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -224,7 +224,7 @@ export const createEvents = (state: RootState) => {
 
     // Get elements that intersect with our pointer
     state.raycaster.castMouse(state.camera, state.mouse)
-    const intersects: Instance[] = state.raycaster.intersectMeshes(interactive)
+    const intersects: OGL.Mesh[] = state.raycaster.intersectMeshes(interactive)
 
     // Used to discern between generic events and custom hover events.
     // We hijack the pointermove event to handle hover state

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 // @ts-ignore
 import * as OGL from 'ogl'
 import { render } from './utils'
-import { Node, extend, reconciler, RootState } from '../src'
+import { Node, extend, reconciler, RootState, createPortal } from '../src'
 
 class CustomElement extends OGL.Transform {}
 
@@ -231,5 +231,27 @@ describe('renderer', () => {
     expect(newInstance.original).not.toBe(true) // Created a new instance
     expect(newInstance.children[0].visible).toBe(false) // Preserves scene hierarchy
     expect(newInstance.test.visible).toBe(true) // Preserves scene hierarchy through attach
+  })
+
+  it('will prepare foreign objects when portaling', async () => {
+    let state: RootState = null!
+    const object = new OGL.Transform()
+    const mesh = React.createRef<OGL.Mesh>()
+
+    await reconciler.act(async () => {
+      state = render(
+        createPortal(
+          <mesh ref={mesh}>
+            <box />
+            <normalProgram />
+          </mesh>,
+          object,
+        ),
+      )
+    })
+
+    expect(state.scene.children.length).toBe(0)
+    expect(object.children.length).not.toBe(0)
+    expect(mesh.current.parent).toBe(object)
   })
 })


### PR DESCRIPTION
Fixes an issue where foreign portal targets not instantiated by react-ogl will desync their children during construction and mount.

```jsx
const object = new Transform()

const Box = (props) => (
  <mesh {...props}>
    <box />
    <normalProgram />
  </mesh>
)

export default (
  <Canvas>
    {createPortal(
      <>
        <Box position={[-1.2, 0, 0]} />
        <Box position={[1.2, 0, 0]} />
      </>,
      object,
    )}
    <primitive object={object} />
  </Canvas>
)
```