### PR TITLE
fix(core): don't use arraybuffer methods

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,7 +140,8 @@ export const applyProps = (instance: Instance, newProps: InstanceProps, oldProps
 
     // Prefer to use properties' copy and set methods
     // otherwise, mutate the property directly
-    if (!ArrayBuffer.isView(value) && typeof target?.set === 'function') {
+    const isMathClass = typeof target?.set === 'function' && typeof target?.copy === 'function'
+    if (!ArrayBuffer.isView(value) && isMathClass) {
       if (target.constructor === value.constructor) {
         target.copy(value)
       } else if (Array.isArray(value)) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -140,8 +140,8 @@ export const applyProps = (instance: Instance, newProps: InstanceProps, oldProps
 
     // Prefer to use properties' copy and set methods
     // otherwise, mutate the property directly
-    if (target?.set) {
-      if (target.constructor.name === value.constructor.name) {
+    if (!ArrayBuffer.isView(value) && typeof target?.set === 'function') {
+      if (target.constructor === value.constructor) {
         target.copy(value)
       } else if (Array.isArray(value)) {
         target.set(...value)

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -128,4 +128,13 @@ describe('applyProps', () => {
     expect(target.position).toBeInstanceOf(OGL.Vec3)
     expect(Array.from(target.position)).toMatchSnapshot()
   })
+
+  it('should properly set array-like buffer views', async () => {
+    const target = {} as unknown as Instance
+    const pixel = new Uint8Array([255, 0, 0, 255])
+
+    applyProps(target, { pixel })
+
+    expect(target.pixel).toBe(pixel)
+  })
 })

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -137,4 +137,14 @@ describe('applyProps', () => {
 
     expect(target.pixel).toBe(pixel)
   })
+
+  it('should properly set non-math classes who implement set', async () => {
+    const target = { test: new Map() } as unknown as Instance
+    const test = new Map()
+    test.set(1, 2)
+
+    applyProps(target, { test })
+
+    expect(target.test).toBe(test)
+  })
 })


### PR DESCRIPTION
Fixes #42 where array-like interfaces like ArrayBuffers or those with set properties (i.e. Map) are incorrectly assumed as math classes.