### PR TITLE
refactor(core): create instances' objects on commit

### DIFF
--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -143,15 +143,19 @@ const switchInstance = (instance: Instance, type: string, props: InstanceProps, 
   const newInstance = createInstance(type, props, root)
 
   // Replace instance in scene-graph
-  removeChild(instance.parent, instance)
-  appendChild(instance.parent, newInstance)
+  const parent = instance.parent
+  removeChild(parent, instance)
+  appendChild(parent, newInstance)
 
+  // Commit new instance object
   commitInstance(newInstance)
 
-  if (newInstance.props.attach) {
-    attach(newInstance.parent, newInstance)
+  // Append to scene-graph
+  if (props.attach) {
+    detach(parent, instance)
+    attach(parent, newInstance)
   } else if (newInstance.object instanceof OGL.Transform) {
-    newInstance.object.setParent(newInstance.parent.object)
+    newInstance.object.setParent(parent.object)
   }
 
   // Move children to new instance

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -86,7 +86,7 @@ const removeChild = (parent: Instance, child: Instance) => {
   if (child.props.attach) detach(parent, child)
   else if (child.object instanceof OGL.Transform) parent.object.removeChild(child.object)
 
-  child.object.dispose?.()
+  if (child.props.dispose !== null) child.object.dispose?.()
   child.object = null
 }
 
@@ -115,15 +115,20 @@ const commitInstance = (instance: Instance) => {
     }
   }
 
+  // Auto-attach geometry and programs to meshes
+  if (!instance.props.attach) {
+    if (instance.object instanceof OGL.Geometry) {
+      instance.props.attach = 'geometry'
+    } else if (instance.object instanceof OGL.Program) {
+      instance.props.attach = 'program'
+    }
+  }
+
   for (const child of instance.children) {
     if (child.props.attach) {
       attach(instance, child)
     } else if (child.object instanceof OGL.Transform) {
       child.object.setParent(instance.object)
-    } else if (child.object instanceof OGL.Geometry) {
-      instance.object.geometry = child.object
-    } else if (child.object instanceof OGL.Program) {
-      instance.object.program = child.object
     }
   }
 
@@ -147,10 +152,6 @@ const switchInstance = (instance: Instance, type: string, props: InstanceProps, 
     attach(newInstance.parent, newInstance)
   } else if (newInstance.object instanceof OGL.Transform) {
     newInstance.object.setParent(newInstance.parent.object)
-  } else if (newInstance.object instanceof OGL.Geometry) {
-    newInstance.parent.object.geometry = newInstance.object
-  } else if (newInstance.object instanceof OGL.Program) {
-    newInstance.parent.object.program = newInstance.object
   }
 
   // Move children to new instance

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -213,7 +213,7 @@ interface PortalRootProps {
 }
 function PortalRoot({ children, target, container }: PortalRootProps) {
   const store = useStore()
-  React.useMemo(() => Object.assign(container, store), [store])
+  React.useMemo(() => Object.assign(container, store), [container, store])
   return <primitive object={target}>{children}</primitive>
 }
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -4,7 +4,7 @@ import { Fiber, ReactPortal } from 'react-reconciler'
 import create, { GetState, SetState } from 'zustand'
 import { reconciler } from './reconciler'
 import { RENDER_MODES } from './constants'
-import { OGLContext, useOGL } from './hooks'
+import { OGLContext, useStore } from './hooks'
 import { Instance, InstanceProps, RenderProps, Root, RootState, RootStore, Subscription } from './types'
 import { applyProps, calculateDpr } from './utils'
 
@@ -206,15 +206,28 @@ export const createRoot = (target: HTMLCanvasElement, config?: RenderProps): Roo
 })
 
 // Prepares portal target
-function PortalRoot({ children, target }: { children: React.ReactElement; target: OGL.Transform }) {
-  const gl = useOGL((state) => state.gl)
-  if (!target.gl) target.gl = gl
-  return children
+interface PortalRootProps {
+  children: React.ReactElement
+  target: OGL.Transform
+  container: any
+}
+function PortalRoot({ children, target, container }: PortalRootProps) {
+  const store = useStore()
+  React.useMemo(() => Object.assign(container, store), [store])
+  return <primitive object={target}>{children}</primitive>
 }
 
 /**
  * Portals into a remote OGL element.
  */
 export const createPortal = (children: React.ReactElement, target: OGL.Transform): ReactPortal => {
-  return reconciler.createPortal(<PortalRoot target={target}>{children}</PortalRoot>, target, null, null)
+  const container = {}
+  return reconciler.createPortal(
+    <PortalRoot target={target} container={container}>
+      {children}
+    </PortalRoot>,
+    container,
+    null,
+    null,
+  )
 }

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -149,7 +149,7 @@ export const render = (
     onResize(state)
 
     // Create root fiber
-    const fiber = reconciler.createContainer(state, RENDER_MODES[mode] ?? RENDER_MODES['blocking'], false, null)
+    const fiber = reconciler.createContainer(store, RENDER_MODES[mode] ?? RENDER_MODES['blocking'], false, null)
 
     // Set root
     root = { fiber, store }
@@ -164,7 +164,9 @@ export const render = (
 
   // Update fiber
   reconciler.updateContainer(
-    <OGLContext.Provider value={root.store}>{element}</OGLContext.Provider>,
+    <OGLContext.Provider value={root.store}>
+      <primitive object={state.scene}>{element}</primitive>
+    </OGLContext.Provider>,
     root.fiber,
     null,
     () => undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 /// <reference types="webxr" />
+import type { Fiber as ReconcilerFiber } from 'react-reconciler'
 import type * as OGL from 'ogl-typescript'
 import type { MutableRefObject } from 'react'
 import type { SetState, GetState, UseBoundStore, StoreApi } from 'zustand'
@@ -34,26 +35,9 @@ export type ObjectMap = {
  */
 export type Catalogue = { [key: string]: any }
 
-export type Attach = string | ((parent: Instance, self: Instance) => () => void)
+export type Attach = string | ((parent: any, self: any) => () => void)
 
-/**
- * Base OGL React instance.
- */
-export type BaseInstance = Omit<OGL.Transform, 'children' | 'attach' | 'parent'> & {
-  gl: OGL.OGLRenderingContext
-  parent: BaseInstance | null
-  isPrimitive?: boolean
-  __handlers?: EventHandlers
-  __attached?: BaseInstance[]
-  __previousAttach?: any
-  children: Instance[]
-  attach?: Attach
-}
-
-/**
- * Extended OGL React instance.
- */
-export type Instance = BaseInstance & { [key: string]: any }
+export type Fiber = ReconcilerFiber & RootStore
 
 /**
  * OGL.Transform React instance.
@@ -63,9 +47,20 @@ export type InstanceProps = {
 } & {
   args?: any[]
   object?: object
-  visible?: boolean
   dispose?: null
   attach?: Attach
+}
+
+/**
+ * Internal react-ogl instance.
+ */
+export interface Instance {
+  root: Fiber
+  parent: Instance | null
+  children: Instance[]
+  type: string
+  props: InstanceProps
+  object: any | null
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,12 +43,11 @@ export const calculateDpr = (dpr: DPR) =>
 /**
  * Resolves a stringified attach type against an `Instance`.
  */
-export const resolveAttach = (instance: Instance, key: string) => {
-  let target = instance
+export const resolveAttach = (target: any, key: string) => {
   if (key.includes('-')) {
     const entries = key.split('-')
     const last = entries.pop() as string
-    target = entries.reduce((acc, key) => acc[key], instance)
+    target = entries.reduce((acc, key) => acc[key], target)
     return { target, key: last }
   } else return { target, key }
 }
@@ -60,24 +59,19 @@ const INDEX_REGEX = /-\d+$/
  * Attaches an instance to a parent via its `attach` prop.
  */
 export const attach = (parent: Instance, child: Instance) => {
-  if (!child.attach) return
-
-  parent.__attached = parent.__attached ?? []
-  parent.__attached.push(child)
-
-  if (typeof child.attach === 'string') {
+  if (typeof child.props.attach === 'string') {
     // If attaching into an array (foo-0), create one
-    if (INDEX_REGEX.test(child.attach)) {
-      const root = child.attach.replace(INDEX_REGEX, '')
-      const { target, key } = resolveAttach(parent, root)
+    if (INDEX_REGEX.test(child.props.attach)) {
+      const root = child.props.attach.replace(INDEX_REGEX, '')
+      const { target, key } = resolveAttach(parent.object, root)
       if (!Array.isArray(target[key])) target[key] = []
     }
 
-    const { target, key } = resolveAttach(parent, child.attach)
-    child.__previousAttach = target[key]
+    const { target, key } = resolveAttach(parent.object, child.props.attach)
+    child.object.__previousAttach = target[key]
     target[key] = child
   } else {
-    child.__previousAttach = child.attach(parent, child)
+    child.object.__previousAttach = child.props.attach(parent.object, child.object)
   }
 }
 
@@ -85,24 +79,20 @@ export const attach = (parent: Instance, child: Instance) => {
  * Removes an instance from a parent via its `attach` prop.
  */
 export const detach = (parent: Instance, child: Instance) => {
-  const attachIndex = parent?.__attached?.indexOf(child)
-  if (typeof attachIndex !== 'number' || attachIndex === -1) return
-
-  child.__previousAttach = undefined
-  parent.__attached.splice(attachIndex, 1)
-
-  if (typeof child.attach === 'string') {
-    const { target, key } = resolveAttach(parent, child.attach)
-    target[key] = child.__previousAttach
+  if (typeof child.props.attach === 'string') {
+    const { target, key } = resolveAttach(parent.object, child.props.attach)
+    target[key] = child.object.__previousAttach
   } else {
-    child.__previousAttach?.(parent, child)
+    child.object.__previousAttach?.(parent.object, child.object)
   }
+
+  delete child.object.__previousAttach
 }
 
 /**
  * Safely mutates an OGL element, respecting special JSX syntax.
  */
-export const applyProps = (instance: Instance, newProps: InstanceProps, oldProps?: InstanceProps) => {
+export const applyProps = (object: any, newProps: InstanceProps, oldProps?: InstanceProps) => {
   // Mutate our OGL element
   for (let key in newProps) {
     // Don't mutate reserved keys
@@ -114,12 +104,12 @@ export const applyProps = (instance: Instance, newProps: InstanceProps, oldProps
     // Collect event handlers
     const isHandler = POINTER_EVENTS.includes(key as typeof POINTER_EVENTS[number])
     if (isHandler) {
-      instance.__handlers = { ...instance.__handlers, [key]: newProps[key] }
+      object.__handlers = { ...object.__handlers, [key]: newProps[key] }
       continue
     }
 
     const value = newProps[key]
-    let root = instance
+    let root = object
     let target = root[key]
 
     // Set deeply nested properties using piercing.
@@ -127,14 +117,14 @@ export const applyProps = (instance: Instance, newProps: InstanceProps, oldProps
     if (key.includes('-')) {
       // Build new target from chained props
       const chain = key.split('-')
-      target = chain.reduce((acc, key) => acc[key], instance)
+      target = chain.reduce((acc, key) => acc[key], object)
 
       // Switch root of target if atomic
       if (!target?.set) {
         // We're modifying the first of the chain instead of element.
         // Remove the key from the chain and target it instead.
         key = chain.pop()
-        root = chain.reduce((acc, key) => acc[key], instance)
+        root = chain.reduce((acc, key) => acc[key], object)
       }
     }
 
@@ -220,7 +210,7 @@ export const createEvents = (state: RootState) => {
     const interactive: OGL.Mesh[] = []
     state.scene.traverse((node: OGL.Mesh) => {
       // Mesh has registered events and a defined volume
-      if ((node as Instance).__handlers && node.geometry?.attributes?.position) interactive.push(node)
+      if (node.__handlers && node.geometry?.attributes?.position) interactive.push(node)
     })
 
     // Get elements that intersect with our pointer
@@ -233,7 +223,7 @@ export const createEvents = (state: RootState) => {
 
     // Trigger events for hovered elements
     for (const object of intersects) {
-      const handlers = object.__handlers
+      const handlers = object.__handlers as EventHandlers
 
       // Bail if object doesn't have handlers (managed externally)
       if (!handlers) continue
@@ -253,8 +243,8 @@ export const createEvents = (state: RootState) => {
 
     // Cleanup stale hover events
     if (isHoverEvent || type === 'onPointerDown') {
-      state.hovered.forEach((object: Instance) => {
-        const handlers = object.__handlers
+      state.hovered.forEach((object: OGL.Mesh) => {
+        const handlers = object.__handlers as EventHandlers
 
         if (!intersects.length || !intersects.find((i) => i === object)) {
           // Reset hover state

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -69,7 +69,7 @@ export const attach = (parent: Instance, child: Instance) => {
 
     const { target, key } = resolveAttach(parent.object, child.props.attach)
     child.object.__previousAttach = target[key]
-    target[key] = child
+    target[key] = child.object
   } else {
     child.object.__previousAttach = child.props.attach(parent.object, child.object)
   }

--- a/tests/events.test.tsx
+++ b/tests/events.test.tsx
@@ -23,7 +23,7 @@ it('handles all interactive meshes', async () => {
   ;(event as any).offsetX = 640
   ;(event as any).offsetY = 400
 
-  fireEvent(canvas.current, event)
+  fireEvent(canvas.current!, event)
 
   expect(handleOnClick).toHaveBeenCalled()
 })
@@ -47,7 +47,7 @@ it('handles onClick', async () => {
   ;(event as any).offsetX = 640
   ;(event as any).offsetY = 400
 
-  fireEvent(canvas.current, event)
+  fireEvent(canvas.current!, event)
 
   expect(handleOnClick).toHaveBeenCalled()
 })
@@ -71,7 +71,7 @@ it('handles onPointerUp', async () => {
   ;(event as any).offsetX = 640
   ;(event as any).offsetY = 400
 
-  fireEvent(canvas.current, event)
+  fireEvent(canvas.current!, event)
 
   expect(handlePointerUp).toHaveBeenCalled()
 })
@@ -95,7 +95,7 @@ it('handles onPointerDown', async () => {
   ;(event as any).offsetX = 640
   ;(event as any).offsetY = 400
 
-  fireEvent(canvas.current, event)
+  fireEvent(canvas.current!, event)
 
   expect(handlePointerDown).toHaveBeenCalled()
 })
@@ -119,7 +119,7 @@ it('handles onPointerMove', async () => {
   ;(event as any).offsetX = 640
   ;(event as any).offsetY = 400
 
-  fireEvent(canvas.current, event)
+  fireEvent(canvas.current!, event)
 
   expect(handlePointerMove).toHaveBeenCalled()
 })
@@ -143,7 +143,7 @@ it('handles onPointerOver', async () => {
   ;(event as any).offsetX = 640
   ;(event as any).offsetY = 400
 
-  fireEvent(canvas.current, event)
+  fireEvent(canvas.current!, event)
 
   expect(handleOnPointerOver).toHaveBeenCalled()
 })
@@ -167,14 +167,14 @@ it('handles onPointerOut', async () => {
   const event = new PointerEvent('pointermove')
   ;(event as any).offsetX = 640
   ;(event as any).offsetY = 400
-  fireEvent(canvas.current, event)
+  fireEvent(canvas.current!, event)
 
   // Move pointer away from mesh
   const event2 = new PointerEvent('pointermove')
   ;(event2 as any).offsetX = 0
   ;(event2 as any).offsetY = 0
 
-  fireEvent(canvas.current, event2)
+  fireEvent(canvas.current!, event2)
 
   expect(handlePointerOut).toHaveBeenCalled()
 })

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -5,7 +5,7 @@ import { reconciler, OGLContext, useOGL, useFrame, RootState, Subscription } fro
 
 describe('useOGL', () => {
   it('should return OGL state', async () => {
-    let state: RootState
+    let state: RootState = null!
 
     const Test = () => {
       state = useOGL()
@@ -38,8 +38,8 @@ describe('useOGL', () => {
 
 describe('useFrame', () => {
   it('should subscribe an element to the frameloop', async () => {
-    let state: RootState
-    let time: number
+    let state: RootState = null!
+    let time: number = null!
 
     const subscribe = (callback: React.MutableRefObject<Subscription>) => {
       callback.current('test' as any, 1)
@@ -73,7 +73,7 @@ describe('useFrame', () => {
     }
 
     const Test = () => {
-      useFrame(null, 1)
+      useFrame(null!, 1)
       return null
     }
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -16,7 +16,7 @@ declare global {
 
 describe('renderer', () => {
   it('should render JSX', async () => {
-    let state: RootState
+    let state: RootState = null!
 
     await reconciler.act(async () => {
       state = render(<transform />)
@@ -26,7 +26,7 @@ describe('renderer', () => {
   })
 
   it('should render extended elements', async () => {
-    let state: RootState
+    let state: RootState = null!
 
     await reconciler.act(async () => {
       extend({ CustomElement })
@@ -39,7 +39,7 @@ describe('renderer', () => {
   })
 
   it('should set pierced props', async () => {
-    let state: RootState
+    let state: RootState = null!
 
     await reconciler.act(async () => {
       state = render(
@@ -56,7 +56,7 @@ describe('renderer', () => {
   })
 
   it('should handle attach', async () => {
-    let state: RootState
+    let state: RootState = null!
 
     await reconciler.act(async () => {
       state = render(
@@ -97,7 +97,7 @@ describe('renderer', () => {
   })
 
   it('should accept vertex and fragment as program args', async () => {
-    let state: RootState
+    let state: RootState = null!
 
     const vertex = 'vertex'
     const fragment = 'fragment'
@@ -118,7 +118,7 @@ describe('renderer', () => {
   })
 
   it('should update program uniforms reactively', async () => {
-    let state: RootState
+    let state: RootState = null!
 
     const Mesh = ({ value }) => (
       <mesh>
@@ -141,7 +141,7 @@ describe('renderer', () => {
   })
 
   it('should accept shorthand props as uniforms', async () => {
-    let state: RootState
+    let state: RootState = null!
 
     const renderer = new OGL.Renderer({ canvas: document.createElement('canvas') })
     const texture = new OGL.Texture(renderer.gl)
@@ -166,7 +166,7 @@ describe('renderer', () => {
   })
 
   it('should accept props as geometry attributes', async () => {
-    let state: RootState
+    let state: RootState = null!
 
     const position = { size: 2, data: new Float32Array([-1, -1, 3, -1, -1, 3]) }
     const uv = { size: 2, data: new Float32Array([0, 0, 2, 0, 0, 2]) }

--- a/tests/native.test.tsx
+++ b/tests/native.test.tsx
@@ -6,7 +6,7 @@ import { Canvas } from '../src/Canvas.native' // explicitly require native modul
 
 describe('Canvas', () => {
   it('should correctly mount', async () => {
-    let renderer: RenderAPI
+    let renderer: RenderAPI = null!
 
     await reconciler.act(async () => {
       renderer = render(

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore
 import * as OGL from 'ogl'
-import { applyProps, Instance } from '../src'
+import { applyProps } from '../src'
 
 describe('applyProps', () => {
   it('should accept shorthand uniforms', async () => {
@@ -96,7 +96,7 @@ describe('applyProps', () => {
   })
 
   it('should prefer to copy from external props', async () => {
-    const target = { color: new OGL.Color() } as unknown as Instance
+    const target = { color: new OGL.Color() }
     target.color.copy = jest.fn()
 
     applyProps(target, {
@@ -108,7 +108,7 @@ describe('applyProps', () => {
   })
 
   it('should spread array prop values', async () => {
-    const target = { position: new OGL.Vec3() } as unknown as Instance
+    const target = { position: new OGL.Vec3() }
 
     applyProps(target, {
       position: [1, 2, 3],
@@ -119,7 +119,7 @@ describe('applyProps', () => {
   })
 
   it('should accept scalar shorthand', async () => {
-    const target = { position: new OGL.Vec3() } as unknown as Instance
+    const target = { position: new OGL.Vec3() }
 
     applyProps(target, {
       position: 3,
@@ -130,7 +130,7 @@ describe('applyProps', () => {
   })
 
   it('should properly set array-like buffer views', async () => {
-    const target = {} as unknown as Instance
+    const target = { pixel: null }
     const pixel = new Uint8Array([255, 0, 0, 255])
 
     applyProps(target, { pixel })
@@ -139,7 +139,7 @@ describe('applyProps', () => {
   })
 
   it('should properly set non-math classes who implement set', async () => {
-    const target = { test: new Map() } as unknown as Instance
+    const target = { test: new Map() }
     const test = new Map()
     test.set(1, 2)
 

--- a/tests/web.test.tsx
+++ b/tests/web.test.tsx
@@ -4,7 +4,7 @@ import { reconciler, Canvas } from '../src'
 
 describe('Canvas', () => {
   it('should correctly mount', async () => {
-    let renderer: RenderResult
+    let renderer: RenderResult = null!
 
     await reconciler.act(async () => {
       renderer = render(


### PR DESCRIPTION
Solves a longstanding issue of OGL's constructor side-effects by creating instances' objects on commit mount instead of alongside instance creation. Instead, instances are descriptors that will create an OGL element once finalized and managed in the tree. This prevents GPU memory leaks that would arise when using suspense or concurrent features whenever instances are discarded and later recreated. Effectful constructors are not a good design, but this way, we work around them.