### PR TITLE
fix(core): handle container append on mount

### DIFF
--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -113,22 +113,32 @@ const commitInstance = (instance: Instance) => {
     } else {
       instance.object = new target(...instance.props.args)
     }
-  }
 
-  // Auto-attach geometry and programs to meshes
-  if (!instance.props.attach) {
-    if (instance.object instanceof OGL.Geometry) {
-      instance.props.attach = 'geometry'
-    } else if (instance.object instanceof OGL.Program) {
-      instance.props.attach = 'program'
+    // Auto-attach geometry and programs to meshes
+    if (!instance.props.attach) {
+      if (instance.object instanceof OGL.Geometry) {
+        instance.props.attach = 'geometry'
+      } else if (instance.object instanceof OGL.Program) {
+        instance.props.attach = 'program'
+      }
+    }
+
+    // Append children
+    for (const child of instance.children) {
+      if (child.props.attach) {
+        attach(instance, child)
+      } else if (child.object instanceof OGL.Transform) {
+        child.object.setParent(instance.object)
+      }
     }
   }
 
-  for (const child of instance.children) {
-    if (child.props.attach) {
-      attach(instance, child)
-    } else if (child.object instanceof OGL.Transform) {
-      child.object.setParent(instance.object)
+  // Append to container
+  if (instance.parent?.object && instance.parent.parent === null) {
+    if (instance.props.attach) {
+      attach(instance.parent, instance)
+    } else if (instance.object instanceof OGL.Transform) {
+      instance.object.setParent(instance.parent.object)
     }
   }
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -92,7 +92,7 @@ const removeChild = (parent: Instance, child: Instance) => {
 
 const commitInstance = (instance: Instance) => {
   // Don't handle commit for containers
-  if (instance.parent === null) return
+  if (!instance.parent) return
 
   if (instance.type !== 'primitive' && !instance.object) {
     const name = toPascalCase(instance.type)
@@ -137,7 +137,7 @@ const commitInstance = (instance: Instance) => {
   }
 
   // Append to container
-  if (instance.parent?.object && instance.parent.parent === null) {
+  if (!instance.parent.parent) {
     if (instance.props.attach) {
       attach(instance.parent, instance)
     } else if (instance.object instanceof OGL.Transform) {

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -91,6 +91,9 @@ const removeChild = (parent: Instance, child: Instance) => {
 }
 
 const commitInstance = (instance: Instance) => {
+  // Don't handle commit for containers
+  if (instance.parent === null) return
+
   if (instance.type !== 'primitive' && !instance.object) {
     const name = toPascalCase(instance.type)
     const target = catalogue[name] ?? OGL[name]
@@ -113,23 +116,23 @@ const commitInstance = (instance: Instance) => {
     } else {
       instance.object = new target(...instance.props.args)
     }
+  }
 
-    // Auto-attach geometry and programs to meshes
-    if (!instance.props.attach) {
-      if (instance.object instanceof OGL.Geometry) {
-        instance.props.attach = 'geometry'
-      } else if (instance.object instanceof OGL.Program) {
-        instance.props.attach = 'program'
-      }
+  // Auto-attach geometry and programs to meshes
+  if (!instance.props.attach) {
+    if (instance.object instanceof OGL.Geometry) {
+      instance.props.attach = 'geometry'
+    } else if (instance.object instanceof OGL.Program) {
+      instance.props.attach = 'program'
     }
+  }
 
-    // Append children
-    for (const child of instance.children) {
-      if (child.props.attach) {
-        attach(instance, child)
-      } else if (child.object instanceof OGL.Transform) {
-        child.object.setParent(instance.object)
-      }
+  // Append children
+  for (const child of instance.children) {
+    if (child.props.attach) {
+      attach(instance, child)
+    } else if (child.object instanceof OGL.Transform) {
+      child.object.setParent(instance.object)
     }
   }
 

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -38,6 +38,22 @@ describe('renderer', () => {
     expect(element instanceof CustomElement).toBe(true)
   })
 
+  it('should complete view on mount', async () => {
+    const lifecycle: string[] = []
+
+    function Test() {
+      React.useLayoutEffect(() => void lifecycle.push('useLayoutEffect'), [])
+      React.useEffect(() => void lifecycle.push('useEffect'), [])
+      return <transform attach={() => (lifecycle.push('attach'), () => {})} />
+    }
+
+    await reconciler.act(async () => {
+      render(<Test />)
+    })
+
+    expect(lifecycle).toStrictEqual(['attach', 'useLayoutEffect', 'useEffect'])
+  })
+
   it('should set pierced props', async () => {
     let state: RootState = null!
 


### PR DESCRIPTION
Fixes attach race conditions with useLayoutEffect by handling container attach for child elements on commit mount. For the root-level container/instance (scene or portal target), this is a no-op.