### PR TITLE
fix(core): don't diff reserved props, skip instance props in applyProps

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,3 +18,13 @@ export const RENDER_MODES = {
   blocking: 1,
   concurrent: 2,
 } as const
+
+/**
+ * React internal props.
+ */
+export const RESERVED_PROPS = ['children', 'key', 'ref', '__self', '__source'] as const
+
+/**
+ * react-ogl instance-specific props.
+ */
+export const INSTANCE_PROPS = ['args', 'object', 'dispose', 'attach']

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -2,6 +2,7 @@ import Reconciler from 'react-reconciler'
 import * as OGL from 'ogl'
 import * as React from 'react'
 import { toPascalCase, applyProps, attach, detach, classExtends } from './utils'
+import { RESERVED_PROPS } from './constants'
 import { Fiber, Instance, InstanceProps } from './types'
 
 // Custom objects that extend the OGL namespace
@@ -231,7 +232,7 @@ const diffProps = (instance: Instance, newProps: InstanceProps, oldProps: Instan
   // Sort through props
   for (const key in newProps) {
     // Skip reserved keys
-    if (key === 'children') continue
+    if (RESERVED_PROPS.includes(key as typeof RESERVED_PROPS[number])) continue
     // Skip primitives
     if (instance.type === 'primitive' && key === 'object') continue
     // Skip if props match

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,8 @@
 import * as React from 'react'
 import * as OGL from 'ogl'
-import { POINTER_EVENTS } from './constants'
+import { RESERVED_PROPS, INSTANCE_PROPS, POINTER_EVENTS } from './constants'
 import { useIsomorphicLayoutEffect } from './hooks'
-import { DPR, EventHandlers, Instance, InstanceProps, RootState } from './types'
+import { DPR, EventHandlers, Instance, RootState } from './types'
 
 /**
  * Converts camelCase primitives to PascalCase.
@@ -78,11 +78,12 @@ export const detach = (parent: Instance, child: Instance) => {
 /**
  * Safely mutates an OGL element, respecting special JSX syntax.
  */
-export const applyProps = (object: any, newProps: InstanceProps, oldProps?: InstanceProps) => {
+export const applyProps = (object: any, newProps: any, oldProps?: any) => {
   // Mutate our OGL element
   for (const prop in newProps) {
     // Don't mutate reserved keys
-    if (prop === 'children') continue
+    if (RESERVED_PROPS.includes(prop as typeof RESERVED_PROPS[number])) continue
+    if (INSTANCE_PROPS.includes(prop as typeof INSTANCE_PROPS[number])) continue
 
     // Don't mutate unchanged keys
     if (newProps[prop] === oldProps?.[prop]) continue

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -1,6 +1,6 @@
 // @ts-ignore
 import * as OGL from 'ogl'
-import { resolve, applyProps } from '../src'
+import { resolve, applyProps, RESERVED_PROPS, INSTANCE_PROPS } from '../src'
 
 describe('resolve', () => {
   it('should resolve pierced props', () => {
@@ -165,5 +165,19 @@ describe('applyProps', () => {
     applyProps(target, { test })
 
     expect(target.test).toBe(test)
+  })
+
+  it('should not set react internal and react-ogl instance props', async () => {
+    const target: any = {}
+
+    applyProps(
+      target,
+      [...RESERVED_PROPS, ...INSTANCE_PROPS].reduce((acc, key, value) => ({ ...acc, [key]: value }), {}),
+    )
+
+    Object.keys(target).forEach((key) => {
+      expect(RESERVED_PROPS).not.toContain(key)
+      expect(INSTANCE_PROPS).not.toContain(key)
+    })
   })
 })


### PR DESCRIPTION
Hardens reconciler and applyProps checks against react-internal props and prevents react-ogl instance props from being applied to objects in applyProps.