### PR TITLE
fix(core): update attach reactively on commit update

### DIFF
--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -340,9 +340,23 @@ export const reconciler = Reconciler({
     root: Fiber,
   ) {
     // If flagged for recreation, swap to a new instance.
-    if (reconstruct) switchInstance(instance, type, newProps, root)
-    // Otherwise, just apply changed props
-    else applyProps(instance.object, changedProps)
+    if (reconstruct) return switchInstance(instance, type, newProps, root)
+
+    // Handle attach update
+    if (changedProps.attach) {
+      if (oldProps.attach) detach(instance.parent, instance)
+
+      if (newProps.attach) {
+        instance.props.attach = newProps.attach
+        attach(instance.parent, instance)
+      }
+    }
+
+    // Update instance props
+    Object.assign(instance.props, changedProps)
+
+    // Apply changed props
+    applyProps(instance.object, changedProps)
   },
   hideInstance(instance: Instance) {
     if (instance.object instanceof OGL.Transform) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,6 +56,7 @@ export const attach = (parent: Instance, child: Instance) => {
     const { root, key } = resolve(parent.object, child.props.attach)
     child.object.__previousAttach = root[key]
     root[key] = child.object
+    child.object.__currentAttach = parent.object.__currentAttach = root[key]
   } else {
     child.object.__previousAttach = child.props.attach(parent.object, child.object)
   }
@@ -66,13 +67,18 @@ export const attach = (parent: Instance, child: Instance) => {
  */
 export const detach = (parent: Instance, child: Instance) => {
   if (typeof child.props.attach === 'string') {
-    const { root, key } = resolve(parent.object, child.props.attach)
-    root[key] = child.object.__previousAttach
+    // Reset parent key if last attached
+    if (parent.object.__currentAttach === child.object.__currentAttach) {
+      const { root, key } = resolve(parent.object, child.props.attach)
+      root[key] = child.object.__previousAttach
+    }
   } else {
-    child.object.__previousAttach?.(parent.object, child.object)
+    child.object.__previousAttach(parent.object, child.object)
   }
 
   delete child.object.__previousAttach
+  delete child.object.__currentAttach
+  delete parent.object.__currentAttach
 }
 
 /**


### PR DESCRIPTION
Updates `attach` reactively on commit update between one or multiple instances (in the case of swapping via state).