### PR TITLE
feat: use @types/ogl drop-in

### DIFF
--- a/examples/src/components/Controls.tsx
+++ b/examples/src/components/Controls.tsx
@@ -14,7 +14,6 @@ function Controls() {
 
   useFrame(() => controls.current.update())
 
-  // @ts-ignore
   return <orbit ref={controls} args={[camera, { element: gl.canvas, enableZoom: false }]} />
 }
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "eslint-plugin-react-hooks": "^4.3.0",
     "expo-gl": "^11.1.1",
     "jest": "^27.4.7",
-    "ogl": "^0.0.81",
+    "ogl": "^0.0.93",
     "prettier": "^2.5.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
@@ -55,8 +55,8 @@
   "dependencies": {
     "@expo/browser-polyfill": "^1.0.0",
     "@types/react-reconciler": "^0.26.4",
+    "@types/ogl": "npm:ogl-types@^0.0.93",
     "@types/webxr": "^0.4.0",
-    "ogl-typescript": "^0.1.40",
     "react-reconciler": "^0.26.2",
     "react-use-measure": "^2.1.1",
     "suspend-react": "^0.0.8",

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -364,7 +364,7 @@ export const reconciler = Reconciler({
   },
   unhideInstance(instance: Instance) {
     if (instance.object instanceof OGL.Transform) {
-      instance.object.visible = instance.props.visible ?? true
+      instance.object.visible = (instance.props.visible as boolean) ?? true
     }
   },
   // Configures a callback once finalized and instances are linked up to one another.

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,20 +1,12 @@
 /// <reference types="webxr" />
 import type { Fiber as ReconcilerFiber } from 'react-reconciler'
-import type * as OGL from 'ogl-typescript'
-import type { MutableRefObject } from 'react'
+import type * as OGL from 'ogl'
+import type * as React from 'react'
 import type { SetState, GetState, UseBoundStore, StoreApi } from 'zustand'
-import { RENDER_MODES } from './constants'
+import type { RENDER_MODES } from './constants'
 
-export interface OGLEvent<TEvent extends Event> {
+export interface OGLEvent<TEvent extends Event> extends Partial<OGL.RaycastHit> {
   nativeEvent: TEvent
-  localPoint: OGL.Vec3
-  point: OGL.Vec3
-  distance: number
-  faceNormal?: OGL.Vec3
-  localFaceNormal?: OGL.Vec3
-  localNormal?: OGL.Vec3
-  normal?: OGL.Vec3
-  uv?: OGL.Vec2
 }
 
 export interface EventHandlers {
@@ -84,6 +76,8 @@ export type Frameloop = 'always' | 'never'
 
 export type Subscription = (state: RootState, time: number, frame?: XRFrame) => any
 
+export type Interactive = OGL.Mesh & { __handlers?: Partial<EventHandlers> }
+
 export interface RootState {
   set: SetState<RootState>
   get: GetState<RootState>
@@ -97,12 +91,12 @@ export interface RootState {
   camera: OGL.Camera
   priority: number
   subscribed: React.MutableRefObject<Subscription>[]
-  subscribe: (refCallback: MutableRefObject<Subscription>, renderPriority?: number) => void
-  unsubscribe: (refCallback: MutableRefObject<Subscription>, renderPriority?: number) => void
+  subscribe: (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => void
+  unsubscribe: (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => void
   events?: EventManager
   mouse?: OGL.Vec2
   raycaster?: OGL.Raycast
-  hovered?: Map<number, OGL.Mesh>
+  hovered?: Map<number, Interactive>
   [key: string]: any
 }
 
@@ -178,7 +172,7 @@ export type Node<T, P> = WithOGLProps<
     dispose?: null
     attach?: Attach
     children?: React.ReactNode
-    ref?: React.Ref<P>
+    ref?: React.Ref<T>
     key?: React.Key
   } & (T extends OGL.Mesh ? EventHandlers : {})
 >
@@ -216,7 +210,7 @@ declare global {
       cylinder: Node<OGL.Cylinder, typeof OGL.Cylinder>
       triangle: Node<OGL.Triangle, typeof OGL.Triangle>
       torus: Node<OGL.Torus, typeof OGL.Torus>
-      // orbit: Node<OGL.Orbit, typeof OGL.Orbit>
+      orbit: Node<OGL.Orbit, typeof OGL.Orbit>
       raycast: Node<OGL.Raycast, typeof OGL.Raycast>
       curve: Node<OGL.Curve, typeof OGL.Curve>
       post: Node<OGL.Post, typeof OGL.Post>
@@ -232,7 +226,7 @@ declare global {
       textureLoader: Node<OGL.TextureLoader, typeof OGL.TextureLoader>
       gLTFLoader: Node<OGL.GLTFLoader, typeof OGL.GLTFLoader>
       gLTFSkin: Node<OGL.GLTFSkin, typeof OGL.GLTFSkin>
-      // basisManager: Node<OGL.BasisManager, typeof OGL.BasisManager>
+      basisManager: Node<OGL.BasisManager, typeof OGL.BasisManager>
     }
   }
 }

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -66,7 +66,7 @@ describe('renderer', () => {
       )
     })
 
-    expect(Object.keys(mesh.current.geometry.attributes)).toStrictEqual(['test'])
+    expect(Object.keys(mesh.current!.geometry.attributes)).toStrictEqual(['test'])
   })
 
   it('should handle attach', async () => {
@@ -127,8 +127,8 @@ describe('renderer', () => {
 
     const [mesh] = state.scene.children as OGL.Mesh[]
 
-    expect(mesh.program.vertex).toBe(vertex)
-    expect(mesh.program.fragment).toBe(fragment)
+    expect((mesh.program as any).vertex).toBe(vertex)
+    expect((mesh.program as any).fragment).toBe(fragment)
   })
 
   it('should update program uniforms reactively', async () => {
@@ -142,10 +142,10 @@ describe('renderer', () => {
     )
 
     await reconciler.act(async () => render(<Test value={false} />))
-    expect(mesh.current.program.uniforms.uniform.value).toBe(false)
+    expect(mesh.current!.program.uniforms.uniform.value).toBe(false)
 
     await reconciler.act(async () => render(<Test value={true} />))
-    expect(mesh.current.program.uniforms.uniform.value).toBe(true)
+    expect(mesh.current!.program.uniforms.uniform.value).toBe(true)
   })
 
   it('should accept shorthand props as uniforms', async () => {
@@ -163,7 +163,7 @@ describe('renderer', () => {
       )
     })
 
-    const { color, vector, textures } = mesh.current.program.uniforms
+    const { color, vector, textures } = mesh.current!.program.uniforms
 
     expect(color.value).toBeInstanceOf(OGL.Color)
     expect(vector.value).toBeInstanceOf(OGL.Vec3)
@@ -187,8 +187,8 @@ describe('renderer', () => {
       )
     })
 
-    expect(mesh.current.geometry.attributes.position).toBeDefined()
-    expect(mesh.current.geometry.attributes.uv).toBeDefined()
+    expect(mesh.current!.geometry.attributes.position).toBeDefined()
+    expect(mesh.current!.geometry.attributes.uv).toBeDefined()
   })
 
   it('should bind & unbind events', async () => {
@@ -257,7 +257,7 @@ describe('renderer', () => {
 
     expect(state.scene.children.length).toBe(0)
     expect(object.children.length).not.toBe(0)
-    expect(mesh.current.parent).toBe(object)
+    expect(mesh.current!.parent).toBe(object)
   })
 
   it('should update attach reactively', async () => {
@@ -274,15 +274,15 @@ describe('renderer', () => {
     )
 
     await reconciler.act(async () => render(<Test first mono />))
-    expect(mesh.current.program).toBe(program1.current)
+    expect(mesh.current!.program).toBe(program1.current)
 
     await reconciler.act(async () => render(<Test mono />, { frameloop: 'never' }))
-    expect(mesh.current.program).toBe(undefined)
+    expect(mesh.current!.program).toBe(undefined)
 
     await reconciler.act(async () => render(<Test first />))
-    expect(mesh.current.program).toBe(program1.current)
+    expect(mesh.current!.program).toBe(program1.current)
 
     await reconciler.act(async () => render(<Test />))
-    expect(mesh.current.program).toBe(program2.current)
+    expect(mesh.current!.program).toBe(program2.current)
   })
 })

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -24,7 +24,7 @@ describe('resolve', () => {
 describe('applyProps', () => {
   it('should accept shorthand uniforms', async () => {
     const canvas = document.createElement('canvas')
-    const gl = canvas.getContext('webgl2')
+    const gl = canvas.getContext('webgl2')! as OGL.OGLRenderingContext
     const program = new OGL.Program(gl, {
       vertex: ' ',
       fragment: ' ',
@@ -43,7 +43,7 @@ describe('applyProps', () => {
 
   it('should convert CSS color names to color uniforms', async () => {
     const canvas = document.createElement('canvas')
-    const gl = canvas.getContext('webgl2')
+    const gl = canvas.getContext('webgl2')! as OGL.OGLRenderingContext
     const program = new OGL.Program(gl, {
       vertex: ' ',
       fragment: ' ',
@@ -61,7 +61,7 @@ describe('applyProps', () => {
 
   it('should convert arrays into vector uniforms', async () => {
     const canvas = document.createElement('canvas')
-    const gl = canvas.getContext('webgl2')
+    const gl = canvas.getContext('webgl2')! as OGL.OGLRenderingContext
     const program = new OGL.Program(gl, {
       vertex: ' ',
       fragment: ' ',
@@ -79,7 +79,7 @@ describe('applyProps', () => {
 
   it('should diff & merge uniforms', async () => {
     const canvas = document.createElement('canvas')
-    const gl = canvas.getContext('webgl2')
+    const gl = canvas.getContext('webgl2')! as OGL.OGLRenderingContext
     const program = new OGL.Program(gl, {
       vertex: ' ',
       fragment: ' ',
@@ -100,7 +100,7 @@ describe('applyProps', () => {
 
   it('should pierce into nested properties', async () => {
     const canvas = document.createElement('canvas')
-    const gl = canvas.getContext('webgl2')
+    const gl = canvas.getContext('webgl2')! as OGL.OGLRenderingContext
     const program = new OGL.Program(gl, {
       vertex: ' ',
       fragment: ' ',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1642,6 +1642,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.13.tgz#5ed7ed7c662948335fcad6c412bb42d99ea754e3"
   integrity sha512-Y86MAxASe25hNzlDbsviXl8jQHb0RDvKt4c40ZJQ1Don0AAL0STLZSs4N+6gLEO55pedy7r2cLwS+ZDxPm/2Bw==
 
+"@types/ogl@npm:ogl-types@^0.0.93":
+  version "0.0.93"
+  resolved "https://registry.yarnpkg.com/ogl-types/-/ogl-types-0.0.93.tgz#6c438ad6e2565914d22ceac746604f538f277e06"
+  integrity sha512-QC4EFD8xJavYWQG/rjXoXuwrRmgsqRJvBjFmstogAH0lUEx03oY7doIm8C/9Nj9MucJdIPfNvmZ0RwTsshcrGw==
+
 "@types/prettier@^2.1.5":
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.3.tgz#a3c65525b91fca7da00ab1a3ac2b5a2a4afbffbf"
@@ -5741,15 +5746,10 @@ object.values@^1.1.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
-ogl-typescript@^0.1.40:
-  version "0.1.40"
-  resolved "https://registry.yarnpkg.com/ogl-typescript/-/ogl-typescript-0.1.40.tgz#511f99f7e924e428552cc8203a1fb92efe807abc"
-  integrity sha512-7lpT8u35jd9W7Q48enrcCEL4H0x4co6pn5t6rXZgQN7UT39mcdzRsSr4ucZDOvfwKkUT+UvH2zw83/9mT59bFQ==
-
-ogl@^0.0.81:
-  version "0.0.81"
-  resolved "https://registry.yarnpkg.com/ogl/-/ogl-0.0.81.tgz#1f1ec32ecb60d4a7e264fc9dec9adfb0424573ec"
-  integrity sha512-w7aEUXgqaFfoiflMWdofWEGa7mgfixVJ/V2BCn7vT1O7cKiwhjpCvH77NkuV8PsN/UebxF/EJPUAvDRcdACLlw==
+ogl@^0.0.93:
+  version "0.0.93"
+  resolved "https://registry.yarnpkg.com/ogl/-/ogl-0.0.93.tgz#9deb437ac292364d0c6dd97ee016c430dc3a1793"
+  integrity sha512-HmkC2s7Ew53kQc3DpGo69M1H0rJXiz/oOTE+gJUFBX68SQcujKO/5NzJdI680edAHOYSpBVQwW/6E/Dk2+nFRQ==
 
 on-finished@~2.3.0:
   version "2.3.0"


### PR DESCRIPTION
Continues #28. Uses types from https://github.com/CodyJasonBennett/ogl-types as `@types/ogl` for OGL types.