### PR TITLE
fix: use useLayoutEffect in native

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -7,10 +7,17 @@ import { buildGraph, classExtends } from './utils'
 
 /**
  * An SSR-friendly useLayoutEffect.
+ *
+ * React currently throws a warning when using useLayoutEffect on the server.
+ * To get around it, we can conditionally useEffect on the server (no-op) and
+ * useLayoutEffect elsewhere.
+ *
+ * @see https://github.com/facebook/react/issues/14927
  */
-const isSSR =
-  typeof window === 'undefined' || !window.navigator || /ServerSideRendering|^Deno\//.test(window.navigator.userAgent)
-export const useIsomorphicLayoutEffect = isSSR ? React.useEffect : React.useLayoutEffect
+export const useIsomorphicLayoutEffect =
+  typeof window !== 'undefined' && (window.document?.createElement || window.navigator?.product === 'ReactNative')
+    ? React.useLayoutEffect
+    : React.useEffect
 
 /**
  * Internal OGL context.


### PR DESCRIPTION
Mirrors https://github.com/reduxjs/react-redux/pull/1444 with a check for react-native in `useIsomorphicLayoutEffect`, so `useEffect` is only used server-side.