### PR TITLE
fix(types): mark OGL helpers as effectful, correctly infer hook types

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -28,6 +28,7 @@
   "rules": {
     "react/display-name": "off",
     "react/prop-types": "off",
+    "no-inner-declarations": "off",
     "no-console": "off",
     "no-empty-pattern": "warn",
     "no-duplicate-imports": "error",
@@ -44,6 +45,7 @@
     "@typescript-eslint/no-explicit-any": "off",
     "@typescript-eslint/ban-types": "off",
     "@typescript-eslint/ban-ts-comment": "off",
+    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-namespace": "off",
     "@typescript-eslint/no-extra-semi": "off",
     "@typescript-eslint/no-inferrable-types": "warn"

--- a/examples/src/components/Controls.tsx
+++ b/examples/src/components/Controls.tsx
@@ -3,7 +3,7 @@ import * as OGL from 'ogl'
 import { useFrame, useOGL } from 'react-ogl'
 
 function Controls() {
-  const controls = React.useRef<OGL.Orbit>()
+  const controls = React.useRef<OGL.Orbit>(null!)
   const gl = useOGL((state) => state.gl)
   const camera = useOGL((state) => state.camera)
 

--- a/examples/src/cubes.tsx
+++ b/examples/src/cubes.tsx
@@ -6,7 +6,7 @@ const hotpink = new OGL.Color(0xfba2d4)
 const orange = new OGL.Color(0xf5ce54)
 
 const Box = (props: JSX.IntrinsicElements['mesh']) => {
-  const mesh = React.useRef<OGL.Mesh>()
+  const mesh = React.useRef<OGL.Mesh>(null!)
   const [hovered, setHover] = React.useState(false)
   const [active, setActive] = React.useState(false)
 

--- a/examples/src/draw-modes.tsx
+++ b/examples/src/draw-modes.tsx
@@ -16,7 +16,7 @@ const Program = () => {
 
   return (
     <program
-      cullFace={null}
+      cullFace={false}
       uniforms-uTime={uTime.current}
       vertex={`
         attribute vec2 uv;

--- a/examples/src/primitives.tsx
+++ b/examples/src/primitives.tsx
@@ -4,7 +4,7 @@ import Controls from './components/Controls'
 
 const Program = () => (
   <program
-    cullFace={null}
+    cullFace={false}
     vertex={`
       attribute vec3 position;
       attribute vec3 normal;

--- a/src/Canvas.native.tsx
+++ b/src/Canvas.native.tsx
@@ -7,8 +7,6 @@ import { RenderProps } from './types'
 import { render, unmountComponentAtNode } from './renderer'
 import '@expo/browser-polyfill'
 
-export type GLContext = ExpoWebGLRenderingContext | WebGLRenderingContext
-
 export interface CanvasProps extends Omit<RenderProps, 'size' | 'dpr'>, ViewProps {
   children: React.ReactNode
   style?: ViewStyle

--- a/src/Canvas.tsx
+++ b/src/Canvas.tsx
@@ -32,7 +32,7 @@ export const Canvas = React.forwardRef<HTMLCanvasElement, CanvasProps>(function 
   },
   forwardedRef,
 ) {
-  const canvasRef = React.useRef<HTMLCanvasElement>()
+  const canvasRef = React.useRef<HTMLCanvasElement>(null!)
   const [div, { width, height }] = useMeasure({
     scroll: true,
     debounce: { scroll: 50, resize: 0 },

--- a/src/events.native.ts
+++ b/src/events.native.ts
@@ -1,4 +1,5 @@
 import { GestureResponderEvent } from 'react-native'
+// @ts-ignore
 import Pressability from 'react-native/Libraries/Pressability/Pressability'
 import { createEvents } from './utils'
 import { EventHandlers, EventManager } from './types'
@@ -23,7 +24,7 @@ export const events: EventManager = {
    */
   connect(canvas, state) {
     // Cleanup old handlers
-    state.events.disconnect?.(canvas, state)
+    state.events!.disconnect?.(canvas, state)
 
     // Event handlers
     const { handleEvent } = createEvents(state)
@@ -41,8 +42,8 @@ export const events: EventManager = {
     }
 
     // Init handlers
-    state.events.handlers = Object.entries(EVENTS).reduce(
-      (acc, [name, type]: [keyof typeof EVENTS, typeof EVENTS[keyof typeof EVENTS]]) => ({
+    state.events!.handlers = Object.entries(EVENTS).reduce(
+      (acc, [name, type]) => ({
         ...acc,
         [name]: (event: GestureResponderEvent) => handleTouch(event, type),
       }),
@@ -50,13 +51,13 @@ export const events: EventManager = {
     )
 
     // Create event manager
-    state.events.connected = new Pressability(state.events.handlers)
+    state.events!.connected = new Pressability(state.events!.handlers)
   },
   /**
    * Deletes and disconnects event listeners from canvas.
    */
-  disconnect(canvas, state) {
+  disconnect(_, state) {
     // Disconnect handlers
-    ;(state.events.connected as any)?.reset?.()
+    ;(state.events!.connected as any)?.reset?.()
   },
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -21,31 +21,31 @@ export const events: EventManager = {
    */
   connect(canvas, state) {
     // Cleanup old handlers
-    state.events?.disconnect?.(canvas, state)
+    state.events!.disconnect?.(canvas, state)
 
     // Get event handler
     const { handleEvent } = createEvents(state)
 
     // Create handlers
-    state.events.handlers = Object.entries(EVENTS).reduce(
-      (acc, [name, [type]]: [keyof typeof EVENTS, typeof EVENTS[keyof typeof EVENTS]]) => ({
+    state.events!.handlers = Object.entries(EVENTS).reduce(
+      (acc, [name, [type]]) => ({
         ...acc,
         [name]: (event: PointerEvent) => handleEvent(event, type),
       }),
-      {},
+      {} as any,
     )
 
     // Register handlers
     for (const key in EVENTS) {
-      const handler = state.events.handlers?.[key]
+      const handler = state.events!.handlers?.[key]
       if (handler) {
-        const [, passive] = EVENTS[key]
+        const [, passive] = EVENTS[key as keyof typeof EVENTS]
         canvas.addEventListener(key, handler, { passive })
       }
     }
 
     // Mark events as connected
-    state.events.connected = true
+    state.events!.connected = true
   },
   /**
    * Deletes and disconnects event listeners from canvas.
@@ -53,13 +53,13 @@ export const events: EventManager = {
   disconnect(canvas, state) {
     // Disconnect handlers
     for (const key in EVENTS) {
-      const handler = state.events.handlers?.[key]
+      const handler = state.events!.handlers?.[key]
       if (handler) {
         canvas.removeEventListener(key, handler as any)
       }
     }
 
     // Mark events as disconnected
-    state.events.connected = false
+    state.events!.connected = false
   },
 }

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -103,7 +103,7 @@ export function render(
         },
         events,
         mouse: new OGL.Vec2(),
-        raycaster: new OGL.Raycast(state.gl),
+        raycaster: new OGL.Raycast(gl),
         hovered: new Map(),
         set,
         get,

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -39,6 +39,7 @@ export function render(
           : typeof config.renderer === 'function'
           ? config.renderer(target)
           : new OGL.Renderer({
+              alpha: true,
               antialias: true,
               powerPreference: 'high-performance',
               ...(config.renderer as any),
@@ -101,6 +102,9 @@ export function render(
           set((state) => ({ priority: state.priority - renderPriority }))
         },
         events,
+        mouse: new OGL.Vec2(),
+        raycaster: new OGL.Raycast(state.gl),
+        hovered: new Map(),
         set,
         get,
       } as RootState
@@ -115,7 +119,7 @@ export function render(
 
     // Toggle rendering modes
     let nextFrame: number
-    const animate = (time = 0, frame?: XRFrame) => {
+    function animate(time = 0, frame?: XRFrame) {
       // Toggle XR rendering
       const state = store.getState()
       const mode = state.xr.session ?? window
@@ -136,7 +140,7 @@ export function render(
     if (state.frameloop !== 'never') animate()
 
     // Handle resize
-    const onResize = (state: RootState) => {
+    function onResize(state: RootState) {
       const { width, height } = state.size
       const projection = state.orthographic ? 'orthographic' : 'perspective'
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,11 +10,17 @@ export interface OGLEvent<TEvent extends Event> extends Partial<OGL.RaycastHit> 
 }
 
 export interface EventHandlers {
+  /** Fired when the mesh is clicked or tapped. */
   onClick?: (event: OGLEvent<MouseEvent>) => void
+  /** Fired when a pointer becomes inactive over the mesh. */
   onPointerUp?: (event: OGLEvent<PointerEvent>) => void
+  /** Fired when a pointer becomes active over the mesh. */
   onPointerDown?: (event: OGLEvent<PointerEvent>) => void
+  /** Fired when a pointer moves over the mesh. */
   onPointerMove?: (event: OGLEvent<PointerEvent>) => void
+  /** Fired when a pointer enters the mesh's bounds. */
   onPointerOver?: (event: OGLEvent<PointerEvent>) => void
+  /** Fired when a pointer leaves the mesh's bounds. */
   onPointerOut?: (event: OGLEvent<PointerEvent>) => void
 }
 
@@ -27,10 +33,14 @@ export type Catalogue = Record<Capitalize<keyof OGLElements>, { new (...args: an
 export type InstanceProps = {
   [key: string]: unknown
 } & {
+  /** Used to instantiate the underlying OGL object. Changing `args` will reconstruct the object and update any associated refs */
   args?: any[]
+  /** An external OGL object to attach this element to */
   object?: any
-  dispose?: null
+  /** Describes how to attach this element via a property or set of add & remove callbacks */
   attach?: Attach
+  /** Optionally opt-out of disposal with `dispose={null}` */
+  dispose?: null
 }
 
 /**
@@ -45,16 +55,6 @@ export interface Instance {
   object: any | null
 }
 
-/**
- * Base react-ogl events.
- */
-export type Events = {
-  onClick: EventListener
-  onPointerUp: EventListener
-  onPointerDown: EventListener
-  onPointerMove: EventListener
-}
-
 export interface XRManager {
   session: XRSession | null
   setSession(session: XRSession | null): void
@@ -64,9 +64,9 @@ export interface XRManager {
 
 export interface EventManager {
   connected: boolean
-  handlers?: any
-  connect?: (target: HTMLCanvasElement, state: RootState) => void
-  disconnect?: (target: HTMLCanvasElement, state: RootState) => void
+  connect: (target: HTMLCanvasElement, state: RootState) => void
+  disconnect: (target: HTMLCanvasElement, state: RootState) => void
+  [name: string]: any
 }
 
 export interface Size {
@@ -150,7 +150,7 @@ interface MathRepresentation extends Array<number> {
   set(...args: any): any
 }
 type MathProps<T extends MathRepresentation> = T | Parameters<T['set']> | number
-type WithMathProps<T> = { [K in keyof T]: T[K] extends MathRepresentation | undefined ? MathProps<T[K]> : T[K] }
+type WithMathProps<T> = { [K in keyof T]: T[K] extends MathRepresentation ? MathProps<T[K]> : T[K] }
 type WithProgramProps<T> = T extends OGL.Program
   ? Omit<T, 'vertex' | 'fragment' | 'uniforms'> & {
       vertex?: string
@@ -177,7 +177,7 @@ export type Node<T, P> = WithOGLProps<
     children?: React.ReactNode
     ref?: React.Ref<T>
     key?: React.Key
-  } & (T extends OGL.Mesh ? EventHandlers : {})
+  } & (T extends OGL.Mesh ? Partial<EventHandlers> : {})
 >
 
 export interface OGLElements {

--- a/tests/utils.test.tsx
+++ b/tests/utils.test.tsx
@@ -1,6 +1,6 @@
-// @ts-ignore
 import * as OGL from 'ogl'
-import { resolve, applyProps, RESERVED_PROPS, INSTANCE_PROPS } from '../src'
+import { resolve, applyProps } from '../src/utils'
+import { RESERVED_PROPS, INSTANCE_PROPS } from '../src/constants'
 
 describe('resolve', () => {
   it('should resolve pierced props', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,18 +3,18 @@
     "outDir": "dist",
     "target": "es6",
     "module": "ESNext",
-    "lib": ["es6", "dom"],
+    "lib": ["ESNext", "dom"],
     "moduleResolution": "node",
     "esModuleInterop": true,
     "jsx": "react",
     "pretty": true,
+    "strict": true,
     "skipLibCheck": true,
     "declaration": true,
     "emitDeclarationOnly": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
-      "react-ogl": ["./src"],
-      "react-ogl/*": ["./src/*"]
+      "react-ogl": ["./src"]
     }
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
Correctly infers return types for `useGraph` and `useLoader` and marks 0.97's helpers as effectful via `extend` for mutable construction.