### PR TITLE
fix: enable tree-shaking in webpack, sourcemaps

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,6 +2,7 @@
   "env": {
     "browser": true,
     "es6": true,
+    "node": true,
     "jest": true
   },
   "plugins": ["@typescript-eslint", "react", "react-hooks", "import"],

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,4 +1,0 @@
-{
-  "extends": "../tsconfig",
-  "include": ["src/**/*"]
-}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "react-native": "./dist/index.native.mjs",
   "sideEffects": false,
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "devDependencies": {
     "@swc/cli": "^0.1.57",
@@ -83,9 +84,9 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "rimraf dist && vite build && vite build && tsc",
+    "build": "rimraf dist && vite build && vite build",
     "test": "jest",
-    "lint": "eslint src/**/*.{ts,tsx}",
+    "lint": "eslint src/**/*.{ts,tsx} && tsc",
     "lint-fix": "prettier . --write && eslint --fix src/**/*.{ts,tsx}"
   }
 }

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -131,7 +131,7 @@ describe('renderer', () => {
   it('should update program uniforms reactively', async () => {
     const mesh = React.createRef<OGL.Mesh>()
 
-    const Test = ({ value }) => (
+    const Test = ({ value }: { value: any }) => (
       <mesh ref={mesh}>
         <box />
         <normalProgram uniforms={{ uniform: { value } }} />

--- a/tests/utils/setupTests.ts
+++ b/tests/utils/setupTests.ts
@@ -97,7 +97,7 @@ jest.mock('react-native', () => ({
 jest.mock('react-native/Libraries/Pressability/Pressability.js', () => ({}))
 jest.mock('@expo/browser-polyfill', () => ({}))
 jest.mock('expo-gl', () => ({
-  GLView: ({ onContextCreate }) => {
+  GLView: ({ onContextCreate }: { onContextCreate: any }) => {
     React.useLayoutEffect(() => {
       const gl = new WebGLRenderingContext({ width: 1280, height: 800 } as HTMLCanvasElement)
       onContextCreate(gl)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,12 +10,10 @@
     "pretty": true,
     "strict": true,
     "skipLibCheck": true,
-    "declaration": true,
-    "emitDeclarationOnly": true,
+    "noEmit": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "react-ogl": ["./src"]
     }
-  },
-  "include": ["src/**/*"]
+  }
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,8 +2,11 @@ import path from 'path'
 import fs from 'fs'
 import { defineConfig } from 'vite'
 
+const NATIVE = fs.existsSync(path.resolve(process.cwd(), 'dist'))
+const entry = NATIVE ? 'index.native' : 'index'
+
 export default defineConfig({
-  root: 'examples',
+  root: process.argv[2] ? undefined : 'examples',
   resolve: {
     alias: {
       'react-ogl': path.resolve(process.cwd(), 'src'),
@@ -11,18 +14,25 @@ export default defineConfig({
   },
   build: {
     minify: false,
-    outDir: path.resolve(process.cwd(), 'dist'),
     emptyOutDir: false,
+    sourcemap: true,
     target: 'es2018',
     lib: {
       formats: ['es'],
-      entry: fs.existsSync(path.resolve(process.cwd(), 'dist'))
-        ? path.resolve(process.cwd(), 'src/index.native.ts')
-        : path.resolve(process.cwd(), 'src/index.ts'),
+      entry: `src/${entry}.ts`,
       fileName: '[name]',
     },
     rollupOptions: {
       external: (id) => !id.startsWith('.') && !path.isAbsolute(id),
+      preserveModules: !NATIVE,
+      sourcemapExcludeSources: true,
     },
   },
+  plugins: [
+    {
+      generateBundle() {
+        this.emitFile({ type: 'asset', fileName: `${entry}.d.ts`, source: `export * from '../src/${entry}'` })
+      },
+    },
+  ],
 })


### PR DESCRIPTION
Webpack does not effectively tree-shake bundled modules, so splitting up the module structure for the web target (see https://github.com/vitejs/vite/issues/5174#issuecomment-1193414981).

Also enables sourcemaps for quality control (since bundles are now divergent), skipping `tsc`.