### PR TITLE
fix: explicitly import entrypoints

### DIFF
--- a/src/events.native.ts
+++ b/src/events.native.ts
@@ -1,6 +1,6 @@
 import { GestureResponderEvent } from 'react-native'
 // @ts-ignore
-import Pressability from 'react-native/Libraries/Pressability/Pressability'
+import Pressability from 'react-native/Libraries/Pressability/Pressability.js'
 import { createEvents } from './utils'
 import { EventHandlers, EventManager } from './types'
 

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -1,5 +1,5 @@
 import Reconciler from 'react-reconciler'
-import { DefaultEventPriority } from 'react-reconciler/constants'
+import { DefaultEventPriority } from 'react-reconciler/constants.js'
 import * as OGL from 'ogl'
 import * as React from 'react'
 import { toPascalCase, applyProps, attach, detach, classExtends } from './utils'

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,7 +1,7 @@
 import * as OGL from 'ogl'
 import * as React from 'react'
 import { ReactPortal } from 'react-reconciler'
-import { ConcurrentRoot } from 'react-reconciler/constants'
+import { ConcurrentRoot } from 'react-reconciler/constants.js'
 import create, { GetState, SetState } from 'zustand'
 import { reconciler } from './reconciler'
 import { OGLContext, useStore } from './hooks'


### PR DESCRIPTION
Fixes withstanding issues from #63 by explicitly importing entry points not defined in `package.json` to play nice with ESM policy.