### PR TITLE
refactor(types): dynamically map OGLElements

### DIFF
--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -5,7 +5,7 @@ import { ConcurrentRoot } from 'react-reconciler/constants.js'
 import create, { GetState, SetState } from 'zustand'
 import { reconciler } from './reconciler'
 import { OGLContext, useStore } from './hooks'
-import { Fiber, Instance, InstanceProps, RenderProps, Root, RootState, RootStore, Subscription } from './types'
+import { RenderProps, Root, RootState, RootStore, Subscription } from './types'
 import { applyProps, calculateDpr } from './utils'
 
 // Store roots here since we can render to multiple targets
@@ -44,8 +44,7 @@ export function render(
               ...(config.renderer as any),
               canvas: target,
             })
-      if (config.renderer && typeof config.renderer !== 'function')
-        applyProps(renderer as unknown as Instance, config.renderer as InstanceProps)
+      if (config.renderer && typeof config.renderer !== 'function') applyProps(renderer as any, config.renderer as any)
 
       renderer.dpr = calculateDpr(dpr)
 
@@ -58,7 +57,7 @@ export function render(
           ? config.camera
           : new OGL.Camera(gl, { fov: 75, near: 1, far: 1000, ...(config.camera as any) })
       camera.position.z = 5
-      if (config.camera) applyProps(camera, config.camera as InstanceProps)
+      if (config.camera) applyProps(camera as any, config.camera as any)
 
       return {
         size,
@@ -156,7 +155,7 @@ export function render(
 
     // Create root container
     const container = reconciler.createContainer(
-      store as Fiber,
+      store,
       ConcurrentRoot,
       null,
       false,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,18 @@
 /// <reference types="webxr" />
-import type { Fiber as ReconcilerFiber } from 'react-reconciler'
 import type * as OGL from 'ogl'
 import type * as React from 'react'
 import type { SetState, GetState, UseBoundStore, StoreApi } from 'zustand'
+
+type Mutable<P> = { [K in keyof P]: P[K] | Readonly<P[K]> }
+type NonFunctionKeys<P> = { [K in keyof P]-?: P[K] extends Function ? never : K }[keyof P]
+type Overwrite<P, O> = Omit<P, NonFunctionKeys<O>> & O
+type Filter<T, O> = T extends []
+  ? []
+  : T extends [infer H, ...infer R]
+  ? H extends O
+    ? Filter<R, O>
+    : [H, ...Filter<R, O>]
+  : T
 
 export interface OGLEvent<TEvent extends Event> extends Partial<OGL.RaycastHit> {
   nativeEvent: TEvent
@@ -21,37 +31,6 @@ export interface EventHandlers {
   onPointerOver?: (event: OGLEvent<PointerEvent>) => void
   /** Fired when a pointer leaves the mesh's bounds. */
   onPointerOut?: (event: OGLEvent<PointerEvent>) => void
-}
-
-export type Attach = string | ((parent: any, self: any) => () => void)
-
-export type Fiber = RootStore & ReconcilerFiber
-
-export type Catalogue = Record<Capitalize<keyof OGLElements>, { new (...args: any): any }>
-
-export type InstanceProps = {
-  [key: string]: unknown
-} & {
-  /** Used to instantiate the underlying OGL object. Changing `args` will reconstruct the object and update any associated refs */
-  args?: any[]
-  /** An external OGL object to attach this element to */
-  object?: any
-  /** Describes how to attach this element via a property or set of add & remove callbacks */
-  attach?: Attach
-  /** Optionally opt-out of disposal with `dispose={null}` */
-  dispose?: null
-}
-
-/**
- * Internal react-ogl instance.
- */
-export interface Instance {
-  root: Fiber
-  parent: Instance | null
-  children: Instance[]
-  type: keyof OGLElements
-  props: InstanceProps
-  object: any | null
 }
 
 export interface XRManager {
@@ -77,8 +56,6 @@ export type Frameloop = 'always' | 'never'
 
 export type Subscription = (state: RootState, time: number, frame?: XRFrame) => any
 
-export type Interactive = OGL.Mesh & { __handlers?: Partial<EventHandlers> }
-
 export interface RootState {
   set: SetState<RootState>
   get: GetState<RootState>
@@ -97,7 +74,7 @@ export interface RootState {
   events?: EventManager
   mouse?: OGL.Vec2
   raycaster?: OGL.Raycast
-  hovered?: Map<number, Interactive>
+  hovered?: Map<number, Instance<OGL.Mesh>['object']>
   [key: string]: any
 }
 
@@ -112,32 +89,88 @@ export interface Root {
 
 export type DPR = [number, number] | number
 
-export type RenderProps = {
+export interface RenderProps {
   size?: Size
   orthographic?: boolean
   frameloop?: Frameloop
   renderer?:
     | ((canvas: HTMLCanvasElement) => OGL.Renderer)
     | OGL.Renderer
-    | WithOGLProps<OGL.Renderer>
+    | OGLElement<typeof OGL.Renderer>
     | Partial<OGL.RendererOptions>
   gl?: OGL.OGLRenderingContext
   dpr?: DPR
-  camera?: OGL.Camera | WithOGLProps<OGL.Camera> | Partial<OGL.CameraOptions>
+  camera?: OGL.Camera | OGLElement<typeof OGL.Camera> | Partial<OGL.CameraOptions>
   scene?: OGL.Transform
   events?: EventManager
   onCreated?: (state: RootState) => any
 }
 
-type NonFunctionKeys<T> = { [K in keyof T]: T[K] extends Function ? never : K }[keyof T]
-type Filter<T, O> = T extends []
-  ? []
-  : T extends [infer H, ...infer R]
-  ? H extends O
-    ? Filter<R, O>
-    : [H, ...Filter<R, O>]
-  : T
-type Args<T> = T extends new (...args: any) => any ? ConstructorParameters<T> : never
+export type Attach<O = any> = string | ((parent: any, self: O) => () => void)
+
+export type ConstructorRepresentation = new (...args: any[]) => any
+
+export interface Catalogue {
+  [name: string]: ConstructorRepresentation
+}
+
+export type Args<T> = T extends ConstructorRepresentation ? ConstructorParameters<T> : any[]
+
+export interface InstanceProps<T = any> {
+  args?: Filter<Args<T>, OGL.OGLRenderingContext>
+  object?: T
+  visible?: boolean
+  dispose?: null
+  attach?: Attach<T>
+}
+
+export interface Instance<O = any> {
+  root: RootStore
+  parent: Instance | null
+  children: Instance[]
+  type: string
+  props: InstanceProps<O> & Record<string, unknown>
+  object: O & { __ogl?: Instance<O>; __handlers: Partial<EventHandlers> }
+  isHidden: boolean
+}
+
+interface MathRepresentation {
+  set(...args: any[]): any
+}
+type MathProps<P> = {
+  [K in keyof P]: P[K] extends infer M ? (M extends MathRepresentation ? M | Parameters<M['set']> | number : {}) : {}
+}
+
+type EventProps<P> = P extends OGL.Mesh ? Partial<EventHandlers> : {}
+
+interface ReactProps<P> {
+  children?: React.ReactNode
+  ref?: React.Ref<P>
+  key?: React.Key
+}
+
+type OGLElementProps<T extends ConstructorRepresentation, P = InstanceType<T>> = Partial<
+  Overwrite<P, ReactProps<P> & MathProps<P> & EventProps<P>>
+>
+
+export type OGLElement<T extends ConstructorRepresentation> = Mutable<
+  Overwrite<OGLElementProps<T>, Omit<InstanceProps<InstanceType<T>>, 'object'>>
+>
+
+// TODO: fix in next types release
+declare module 'ogl' {
+  // @ts-ignore
+  class NormalProgram extends OGL.Program {
+    constructor(gl: OGL.OGLRenderingContext)
+  }
+}
+
+type OGLExports = typeof OGL
+type OGLElementsImpl = {
+  [K in keyof OGLExports as Uncapitalize<K>]: OGLExports[K] extends ConstructorRepresentation
+    ? OGLElement<OGLExports[K]>
+    : never
+}
 
 type ColorNames = 'black' | 'white' | 'red' | 'green' | 'blue' | 'fuchsia' | 'cyan' | 'yellow' | 'orange'
 type UniformValue = ColorNames | number | number[] | OGL.Texture | OGL.Texture[]
@@ -146,93 +179,19 @@ type UniformList = {
   [uniform: string]: UniformRepresentation | { value: UniformRepresentation }
 }
 
-interface MathRepresentation extends Array<number> {
-  set(...args: any): any
-}
-type MathProps<T extends MathRepresentation> = T | Parameters<T['set']> | number
-type WithMathProps<T> = { [K in keyof T]: T[K] extends MathRepresentation ? MathProps<T[K]> : T[K] }
-type WithProgramProps<T> = T extends OGL.Program
-  ? Omit<T, 'vertex' | 'fragment' | 'uniforms'> & {
+export interface OGLElements extends OGLElementsImpl {
+  primitive: Omit<OGLElement<any>, 'args'> & { object: any }
+  program: Overwrite<
+    OGLElement<typeof OGL.Program>,
+    {
       vertex?: string
       fragment?: string
       uniforms?: UniformList
     }
-  : T
-type WithGeometryProps<T> = T extends OGL.Geometry
-  ? T & {
-      [name: string]: Partial<Omit<OGL.Attribute, 'data'>> & Required<Pick<OGL.Attribute, 'data'>>
-    }
-  : T
-export type WithOGLProps<T, O = {}> = Partial<
-  WithGeometryProps<WithProgramProps<WithMathProps<Omit<T, NonFunctionKeys<O>>>>>
-> &
-  O
-
-export type Node<T, P> = WithOGLProps<
-  T,
-  {
-    args?: Filter<Args<P>, OGL.OGLRenderingContext>
-    dispose?: null
-    attach?: Attach
-    children?: React.ReactNode
-    ref?: React.Ref<T>
-    key?: React.Key
-  } & (T extends OGL.Mesh ? Partial<EventHandlers> : {})
->
-
-export interface OGLElements {
-  // primitive
-  primitive: Omit<Node<{}, {}>, 'args'> & { object: any }
-
-  // Core
-  geometry: Node<OGL.Geometry, typeof OGL.Geometry>
-  program: Node<OGL.Program, typeof OGL.Program>
-  renderer: Node<OGL.Renderer, typeof OGL.Renderer>
-  camera: Node<OGL.Camera, typeof OGL.Camera>
-  transform: Node<OGL.Transform, typeof OGL.Transform>
-  mesh: Node<OGL.Mesh, typeof OGL.Mesh>
-  texture: Node<OGL.Texture, typeof OGL.Texture>
-  renderTarget: Node<OGL.RenderTarget, typeof OGL.RenderTarget>
-
-  // Math
-  color: Node<OGL.Color, typeof OGL.Color>
-  euler: Node<OGL.Euler, typeof OGL.Euler>
-  mat3: Node<OGL.Mat3, typeof OGL.Mat3>
-  mat4: Node<OGL.Mat4, typeof OGL.Mat4>
-  quat: Node<OGL.Quat, typeof OGL.Quat>
-  vec2: Node<OGL.Vec2, typeof OGL.Vec2>
-  vec3: Node<OGL.Vec3, typeof OGL.Vec3>
-  vec4: Node<OGL.Vec4, typeof OGL.Vec4>
-
-  // Extra
-  plane: Node<OGL.Plane, typeof OGL.Plane>
-  box: Node<OGL.Box, typeof OGL.Box>
-  sphere: Node<OGL.Sphere, typeof OGL.Sphere>
-  cylinder: Node<OGL.Cylinder, typeof OGL.Cylinder>
-  triangle: Node<OGL.Triangle, typeof OGL.Triangle>
-  torus: Node<OGL.Torus, typeof OGL.Torus>
-  orbit: Node<OGL.Orbit, typeof OGL.Orbit>
-  raycast: Node<OGL.Raycast, typeof OGL.Raycast>
-  curve: Node<OGL.Curve, typeof OGL.Curve>
-  post: Node<OGL.Post, typeof OGL.Post>
-  skin: Node<OGL.Skin, typeof OGL.Skin>
-  animation: Node<OGL.Animation, typeof OGL.Animation>
-  text: Node<OGL.Text, typeof OGL.Text>
-  normalProgram: Node<OGL.Program, typeof OGL.Program>
-  flowmap: Node<OGL.Flowmap, typeof OGL.Flowmap>
-  gPGPU: Node<OGL.GPGPU, typeof OGL.GPGPU>
-  polyline: Node<OGL.Polyline, typeof OGL.Polyline>
-  shadow: Node<OGL.Shadow, typeof OGL.Shadow>
-  kTXTexture: Node<OGL.KTXTexture, typeof OGL.KTXTexture>
-  textureLoader: Node<OGL.TextureLoader, typeof OGL.TextureLoader>
-  gLTFLoader: Node<OGL.GLTFLoader, typeof OGL.GLTFLoader>
-  gLTFSkin: Node<OGL.GLTFSkin, typeof OGL.GLTFSkin>
-  basisManager: Node<OGL.BasisManager, typeof OGL.BasisManager>
-  axesHelper: Node<OGL.AxesHelper, typeof OGL.AxesHelper>
-  faceNormalsHelper: Node<OGL.FaceNormalsHelper, typeof OGL.FaceNormalsHelper>
-  gridHelper: Node<OGL.GridHelper, typeof OGL.GridHelper>
-  vertexNormalsHelper: Node<OGL.VertexNormalsHelper, typeof OGL.VertexNormalsHelper>
-  wireMesh: Node<OGL.WireMesh, typeof OGL.WireMesh>
+  >
+  geometry: OGLElement<typeof OGL.Geometry> & {
+    [name: string]: Partial<Omit<OGL.Attribute, 'data'>> & Required<Pick<OGL.Attribute, 'data'>>
+  }
 }
 
 declare global {

--- a/tests/index.test.tsx
+++ b/tests/index.test.tsx
@@ -1,13 +1,13 @@
 import * as React from 'react'
 import * as OGL from 'ogl'
 import { render } from './utils'
-import { Node, extend, act, RootState, createPortal } from '../src'
+import { OGLElement, extend, act, RootState, createPortal } from '../src'
 
 class CustomElement extends OGL.Transform {}
 
 declare module '../src' {
   interface OGLElements {
-    customElement: Node<CustomElement, typeof CustomElement>
+    customElement: OGLElement<typeof CustomElement>
   }
 }
 


### PR DESCRIPTION
Mirrors type enhancements from https://github.com/pmndrs/react-three-fiber/pull/2465.

### Dynamically mapped OGLElements

Additionally, OGL types for `JSX.IntrinsicElements` are no longer hard-coded and dynamically mapped to `OGLElements`. This lets us properly follow semver once `@types/ogl` is upstreamed.

### Node => OGLElement

The `Node` interface has been simplified and renamed to `OGLElement` to prevent clashing with DOM types:

```tsx
declare module 'react-ogl' {
  interface ThreeElements {
    customElement: OGLElement<typeof CustomElement>
  }
}

extend({ CustomElement })
```