### PR TITLE
feat: container effects, recursive dispose, portal state

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 - [Canvas](#canvas)
   - [Canvas Props](#canvas-props)
   - [Custom Canvas](#custom-canvas)
-  - [Testing](#testing)
   - [Root State](#root-state)
 - [Creating Elements](#creating-elements)
   - [JSX, properties, and shortcuts](#jsx-properties-and-shortcuts)
@@ -39,6 +38,7 @@
   - [Access internals via `useInstanceHandle`](#access-internals-via-useinstancehandle)
 - [Events](#events)
   - [Custom Events](#custom-events)
+- [Testing](#testing)
 
 ## Installation
 
@@ -325,30 +325,6 @@ function CustomCanvas({ children }) {
   // Use callback-style ref to access canvas in render
   return <canvas ref={setCanvas} />
 }
-```
-
-### Testing
-
-In addition to `createRoot` (see [custom canvas](#custom-canvas)), react-ogl exports an internal `reconciler` which can be used to safely flush async effects in tests via `reconciler#act`. The following emulates a legacy root and asserts against `RootState` (see [root state](#root-state)).
-
-```tsx
-import * as React from 'react'
-import * as OGL from 'ogl'
-import { type RootState, createRoot, act } from 'react-ogl'
-
-it('tests against a react-ogl component or scene', async () => {
-  const transform = React.createRef<OGL.Transform>()
-  let state: RootState = null!
-
-  await act(async () => {
-    const root = createRoot(document.createElement('canvas'))
-    state = root.render(<transform ref={transform} />).getState()
-  })
-
-  expect(transform.current).toBeInstanceOf(OGL.Transform)
-  expect(state.scene.children.length).toBe(1)
-  expect(state.scene.children[0]).toBe(transform.current)
-})
 ```
 
 ### Root State
@@ -779,3 +755,24 @@ const events = {
 ```
 
 </details>
+
+## Testing
+
+In addition to `createRoot` (see [custom canvas](#custom-canvas)), react-ogl exports an internal `act` which can be used to safely flush async effects in tests. The following emulates a legacy root and asserts against `RootState` (see [root state](#root-state)).
+
+```tsx
+import * as React from 'react'
+import * as OGL from 'ogl'
+import { type Root, type RootStore, type RootState, createRoot, act } from 'react-ogl'
+
+it('tests against a react-ogl component or scene', async () => {
+  const transform = React.createRef<OGL.Transform>()
+
+  const root: Root = createRoot(document.createElement('canvas'))
+  const store: RootStore = await act(async () => root.render(<transform ref={transform} />))
+  const state: RootState = store.getState()
+
+  expect(transform.current).toBeInstanceOf(OGL.Transform)
+  expect(state.scene.children).toStrictEqual([transform.current])
+})
+```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ react-ogl itself is super minimal, but you can use the familiar [@react-three/fi
 
 This example uses [`create-react-app`](https://reactjs.org/docs/create-a-new-react-app.html#create-react-app) for the sake of simplicity, but you can use your own environment or [create a codesandbox](https://react.new).
 
+<details>
+  <summary>Show full example</summary>
+  
+  <br />
+
 ```bash
 # Create app
 npx create-react-app my-app
@@ -143,9 +148,16 @@ createRoot(document.getElementById('root')).render(
 )
 ```
 
+</details>
+
 ### react-native
 
 This example uses [`expo-cli`](https://docs.expo.dev/get-started/create-a-new-app) but you can create a bare app with `react-native` CLI as well.
+
+<details>
+  <summary>Show full example</summary>
+  
+  <br />
 
 ```bash
 # Create app and cd into it
@@ -243,6 +255,8 @@ export default () => (
   </Canvas>
 )
 ```
+
+</details>
 
 ## Canvas
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 - [Canvas](#canvas)
   - [Canvas Props](#canvas-props)
   - [Custom Canvas](#custom-canvas)
-  - [Root State](#root-state)
 - [Creating Elements](#creating-elements)
   - [JSX, properties, and shortcuts](#jsx-properties-and-shortcuts)
   - [Setting constructor arguments via `args`](#setting-constructor-arguments-via-args)
@@ -30,6 +29,7 @@
   - [Creating custom elements via `extend`](#creating-custom-elements-via-extend)
   - [Adding third-party objects via `<primitive />`](#adding-third-party-objects-via-primitive-)
 - [Hooks](#hooks)
+  - [Root State](#root-state)
   - [Accessing state via `useOGL`](#accessing-state-via-useogl)
   - [Frameloop subscriptions via `useFrame`](#frameloop-subscriptions-via-useframe)
   - [Loading assets via `useLoader`](#loading-assets-via-useloader)
@@ -327,41 +327,6 @@ function CustomCanvas({ children }) {
 }
 ```
 
-### Root State
-
-Each `<Canvas />` or `Root` encapsulates its own OGL state via [React context](https://reactjs.org/docs/context.html) and a [Zustand](https://github.com/pmndrs/zustand) store, as defined by `RootState`. This can be accessed and modified with the `onCreated` canvas prop, and with hooks like `useOGL` (see [hooks](#hooks)).
-
-```tsx
-interface RootState {
-  // Zustand setter and getter for live state manipulation.
-  // See https://github.com/pmndrs/zustand
-  get(): RootState
-  set(fn: (previous: RootState) => (next: Partial<RootState>)): void
-  // Canvas layout information
-  size: { width: number; height: number }
-  // OGL scene internals
-  renderer: OGL.Renderer
-  gl: OGL.OGLRenderingContext
-  scene: OGL.Transform
-  camera: OGL.Camera
-  // OGL perspective and frameloop preferences
-  orthographic: boolean
-  frameloop: 'always' | 'never'
-  // Internal XR manager to enable WebXR features
-  xr: XRManager
-  // Frameloop internals for custom render loops
-  priority: number
-  subscribed: React.MutableRefObject<Subscription>[]
-  subscribe: (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => void
-  unsubscribe: (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => void
-  // Optional canvas event manager and its state
-  events?: EventManager
-  mouse: OGL.Vec2
-  raycaster: OGL.Raycast
-  hovered: Map<number, Instance<OGL.Mesh>['object']>
-}
-```
-
 ## Creating elements
 
 react-ogl renders React components into an OGL scene-graph, and can be used on top of other renderers like [react-dom](https://npmjs.com/react-dom) and [react-native](https://npmjs.com/react-native) that render for web and native, respectively. react-ogl components are defined by primitives or lower-case elements native to the OGL namespace (for custom elements, see [extend](#creating-custom-elements-via-extend)).
@@ -539,6 +504,41 @@ const object = new OGL.Transform()
 ## Hooks
 
 react-ogl ships with hooks that allow you to tie or request information to your components. These are called within the body of `<Canvas />` and contain imperative and possibly stateful code.
+
+### Root State
+
+Each `<Canvas />` or `Root` encapsulates its own OGL state via [React context](https://reactjs.org/docs/context.html) and a [Zustand](https://github.com/pmndrs/zustand) store, as defined by `RootState`. This can be accessed and modified with the `onCreated` canvas prop, and with hooks like `useOGL`.
+
+```tsx
+interface RootState {
+  // Zustand setter and getter for live state manipulation.
+  // See https://github.com/pmndrs/zustand
+  get(): RootState
+  set(fn: (previous: RootState) => (next: Partial<RootState>)): void
+  // Canvas layout information
+  size: { width: number; height: number }
+  // OGL scene internals
+  renderer: OGL.Renderer
+  gl: OGL.OGLRenderingContext
+  scene: OGL.Transform
+  camera: OGL.Camera
+  // OGL perspective and frameloop preferences
+  orthographic: boolean
+  frameloop: 'always' | 'never'
+  // Internal XR manager to enable WebXR features
+  xr: XRManager
+  // Frameloop internals for custom render loops
+  priority: number
+  subscribed: React.MutableRefObject<Subscription>[]
+  subscribe: (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => void
+  unsubscribe: (refCallback: React.MutableRefObject<Subscription>, renderPriority?: number) => void
+  // Optional canvas event manager and its state
+  events?: EventManager
+  mouse: OGL.Vec2
+  raycaster: OGL.Raycast
+  hovered: Map<number, Instance<OGL.Mesh>['object']>
+}
+```
 
 ### Accessing state via `useOGL`
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
   - [Access internals via `useInstanceHandle`](#access-internals-via-useinstancehandle)
 - [Events](#events)
   - [Custom Events](#custom-events)
+- [Portals](#portals)
 - [Testing](#testing)
 
 ## Installation
@@ -769,6 +770,24 @@ const events = {
 ```
 
 </details>
+
+## Portals
+
+Portal children into a foreign OGL element via `createPortal`, which can modify children's `RootState`. This is particularly useful for postprocessing and complex render effects.
+
+```tsx
+function Component {
+  // scene & camera are inherited from portal parameters
+  const { scene, camera, ... } = useOGL()
+}
+
+const scene = new OGL.Transform()
+const camera = new OGL.Camera()
+
+<transform>
+  {createPortal(<Component />, scene, { camera })
+</transform>
+```
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "@types/webxr": "^0.5.0",
     "react-reconciler": "^0.27.0",
     "react-use-measure": "^2.1.1",
+    "scheduler": "^0.23.0",
     "suspend-react": "^0.0.8",
     "zustand": "^3.7.1"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -13,7 +13,7 @@ export const POINTER_EVENTS = [
 /**
  * React internal props.
  */
-export const RESERVED_PROPS = ['children', 'key', 'ref', '__self', '__source'] as const
+export const RESERVED_PROPS = ['children', 'key', 'ref', '__self', '__source']
 
 /**
  * react-ogl instance-specific props.

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -26,7 +26,10 @@ export const useIsomorphicLayoutEffect =
  */
 export function useInstanceHandle<O>(ref: React.MutableRefObject<O>): React.MutableRefObject<Instance> {
   const instance = React.useRef<Instance>(null!)
-  useIsomorphicLayoutEffect(() => void (instance.current = (ref.current as unknown as any).__ogl), [ref])
+  useIsomorphicLayoutEffect(
+    () => void (instance.current = (ref.current as unknown as Instance<O>['object']).__ogl!),
+    [ref],
+  )
   return instance
 }
 

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,12 +1,11 @@
 import * as OGL from 'ogl'
 import * as React from 'react'
-import { ReactPortal } from 'react-reconciler'
 import { ConcurrentRoot } from 'react-reconciler/constants.js'
 import create, { GetState, SetState } from 'zustand'
 import { reconciler } from './reconciler'
-import { OGLContext, useStore } from './hooks'
+import { OGLContext, useStore, useIsomorphicLayoutEffect } from './hooks'
 import { RenderProps, Root, RootState, RootStore, Subscription } from './types'
-import { applyProps, calculateDpr } from './utils'
+import { applyProps, calculateDpr, prepare } from './utils'
 
 // Store roots here since we can render to multiple targets
 const roots = new Map<HTMLCanvasElement, { container: any; store: RootStore }>()
@@ -108,8 +107,11 @@ export function render(
       } as RootState
     }) as RootStore
 
-    // Bind events
+    // Prepare scene
     const state = store.getState()
+    prepare(state.scene, store, '', {})
+
+    // Bind events
     if (state.events?.connect && !state.events?.connected) state.events.connect(target, state)
 
     // Handle callback
@@ -178,9 +180,7 @@ export function render(
 
   // Update contanier
   reconciler.updateContainer(
-    <OGLContext.Provider value={root.store}>
-      <primitive object={state.scene}>{element}</primitive>
-    </OGLContext.Provider>,
+    <OGLContext.Provider value={root.store}>{element}</OGLContext.Provider>,
     root.container,
     null,
     () => undefined,
@@ -219,29 +219,32 @@ export const createRoot = (target: HTMLCanvasElement, config?: RenderProps): Roo
   unmount: () => unmountComponentAtNode(target),
 })
 
-// Prepares portal target
 interface PortalRootProps {
   children: React.ReactElement
   target: OGL.Transform
-  container: any
 }
-function PortalRoot({ children, target, container }: PortalRootProps) {
+function PortalRoot({ children, target }: PortalRootProps): JSX.Element {
   const store = useStore()
-  React.useMemo(() => Object.assign(container, store), [container, store])
-  return <primitive object={target}>{children}</primitive>
+  const container = React.useMemo(
+    () =>
+      create((set: SetState<RootState>, get: GetState<RootState>) => ({
+        ...store.getState(),
+        set,
+        get,
+        scene: target,
+      })),
+    [store, target],
+  )
+  useIsomorphicLayoutEffect(() => {
+    const { set, get, scene } = container.getState()
+    return store.subscribe((state) => container.setState({ ...state, set, get, scene }))
+  }, [container, store])
+  return <>{reconciler.createPortal(children, container, null, null)}</>
 }
 
 /**
  * Portals into a remote OGL element.
  */
-export function createPortal(children: React.ReactElement, target: OGL.Transform): ReactPortal {
-  const container = {}
-  return reconciler.createPortal(
-    <PortalRoot target={target} container={container}>
-      {children}
-    </PortalRoot>,
-    container,
-    null,
-    null,
-  )
+export function createPortal(children: React.ReactElement, target: OGL.Transform): JSX.Element {
+  return <PortalRoot target={target}>{children}</PortalRoot>
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -78,7 +78,7 @@ export interface RootState {
   [key: string]: any
 }
 
-export type Act = (cb: () => Promise<any>) => Promise<any>
+export type Act = <T = any>(cb: () => Promise<T>) => Promise<T>
 
 export type RootStore = UseBoundStore<RootState, StoreApi<RootState>>
 

--- a/tests/utils/setupTests.ts
+++ b/tests/utils/setupTests.ts
@@ -10,7 +10,10 @@ declare global {
 global.IS_REACT_ACT_ENVIRONMENT = true
 
 // Mock scheduler to test React features
-jest.mock('scheduler', () => require('scheduler/unstable_mock'))
+jest.mock('scheduler', () => ({
+  ...jest.requireActual('scheduler/unstable_mock'),
+  unstable_scheduleCallback: (_: any, callback: () => void) => callback(),
+}))
 
 // Polyfill PointerEvent
 if (!global.PointerEvent) {


### PR DESCRIPTION
Mirrors container effects from https://github.com/pmndrs/react-three-fiber/pull/2483, moving #44 to before mount and making use of container methods. Also cleans up leaf children to prevent memory leaks from subtrees.

Additionally, Portals now create state enclaves to isolate scenes, cameras, etc. from the root store. This is particularly useful for postprocessing and complex effects.

```tsx
function Component {
  // scene & camera are inherited from portal parameters
  const { scene, camera, ... } = useOGL()
}

const scene = new OGL.Transform()
const camera = new OGL.Camera()

<transform>
  {createPortal(<Component />, scene, { camera })
</transform>
```