### PR TITLE
experiment: add module field for bundlephobia

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Cody Bennett (https://github.com/codyjasonbennett)",
   "license": "MIT",
   "types": "./dist/index.d.ts",
+  "module": "./dist/index.mjs",
   "exports": "./dist/index.mjs",
   "react-native": "./dist/index.native.mjs",
   "sideEffects": false,


### PR DESCRIPTION
Adds the legacy `module` field so Bundlephobia can resolve this package right.