### PR TITLE
feat(Canvas): bridge cross-container context

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "@types/ogl": "npm:ogl-types@^0.0.99",
     "@types/react-reconciler": "^0.26.7",
     "@types/webxr": "^0.5.0",
+    "its-fine": "^1.0.0",
     "react-reconciler": "^0.27.0",
     "react-use-measure": "^2.1.1",
     "scheduler": "^0.23.0",

--- a/tests/native.test.tsx
+++ b/tests/native.test.tsx
@@ -16,7 +16,7 @@ describe('Canvas', () => {
       )
     })
 
-    expect(renderer.toTree()).toMatchSnapshot()
+    expect(renderer.toJSON()).toMatchSnapshot()
   })
 
   it('should forward ref', async () => {
@@ -31,6 +31,28 @@ describe('Canvas', () => {
     })
 
     expect(ref.current).toBeDefined()
+  })
+
+  it('should forward context', async () => {
+    const ParentContext = React.createContext<boolean>(null!)
+    let receivedValue!: boolean
+
+    function Test() {
+      receivedValue = React.useContext(ParentContext)
+      return null
+    }
+
+    await act(async () => {
+      create(
+        <ParentContext.Provider value={true}>
+          <Canvas>
+            <Test />
+          </Canvas>
+        </ParentContext.Provider>,
+      )
+    })
+
+    expect(receivedValue).toBe(true)
   })
 
   it('should correctly unmount', async () => {

--- a/tests/web.test.tsx
+++ b/tests/web.test.tsx
@@ -31,6 +31,28 @@ describe('Canvas', () => {
     expect(ref.current).toBeDefined()
   })
 
+  it('should forward context', async () => {
+    const ParentContext = React.createContext<boolean>(null!)
+    let receivedValue!: boolean
+
+    function Test() {
+      receivedValue = React.useContext(ParentContext)
+      return null
+    }
+
+    await act(async () => {
+      render(
+        <ParentContext.Provider value={true}>
+          <Canvas>
+            <Test />
+          </Canvas>
+        </ParentContext.Provider>,
+      )
+    })
+
+    expect(receivedValue).toBe(true)
+  })
+
   it('should correctly unmount', async () => {
     let renderer: RenderResult
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1623,6 +1623,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-reconciler@^0.28.0":
+  version "0.28.0"
+  resolved "https://registry.yarnpkg.com/@types/react-reconciler/-/react-reconciler-0.28.0.tgz#513acbed173140e958c909041ca14eb40412077f"
+  integrity sha512-5cjk9ottZAj7eaTsqzPUIlrVbh3hBAO2YaEL1rkjHKB3xNAId7oU8GhzvAX+gfmlfoxTwJnBjPxEHyxkEA1Ffg==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^18.0.17":
   version "18.0.17"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.0.17.tgz#4583d9c322d67efe4b39a935d223edcc7050ccf4"
@@ -4182,6 +4189,13 @@ istanbul-reports@^3.1.3:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+its-fine@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.0.0.tgz#e1c17f4420a433c9e96d264330e96a82c6edc33b"
+  integrity sha512-EEVcyr+sR21lxLZg3U84HpY3Mb9aKmGYqxPsIbf/Ea4fO4qpvE/7lX5qtrkuCnljJ9RLMaSaeMq35PeLa+oM0w==
+  dependencies:
+    "@types/react-reconciler" "^0.28.0"
 
 jest-changed-files@^28.1.3:
   version "28.1.3"


### PR DESCRIPTION
Implements a context bridge within `Canvas`. This enables react-ogl children to consume context between renderers (e.g. `react-dom` or `react-native`), removing the need for manually bridging context.

```jsx
import * as React from 'react'
import * as ReactDOM from 'react-dom/client'
import { Canvas } from 'react-ogl'

const DOMContext = React.createContext()

function Component() {
  // "Hello from react-dom"
  console.log(React.useContext(DOMContext))
}

ReactDOM.createRoot(document.getElementById('root')).render(
  <DOMContext.Provider value="Hello from react-dom">
    <Canvas>
      <Component />
    </Canvas>
  </DOMContext.Provider>,
)
```