### PR TITLE
fix: pin Zustand to brace against 4.3.x breaking changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "react-use-measure": "^2.1.1",
     "scheduler": "^0.23.0",
     "suspend-react": "^0.0.8",
-    "zustand": "^4.1.2"
+    "zustand": "~4.2.0"
   },
   "peerDependencies": {
     "expo-gl": ">=11.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7348,9 +7348,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zustand@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.1.2.tgz#4912b24741662d8a84ed1cb52198471cb369c4b6"
-  integrity sha512-gcRaKchcxFPbImrBb/BKgujOhHhik9YhVpIeP87ETT7uokEe2Szu7KkuZ9ghjtD+/KKkcrRNktR2AiLXPIbKIQ==
+zustand@~4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.2.0.tgz#f6ef9e63794eda9b296979578538a6df6be3e1b0"
+  integrity sha512-eNwaDoD2FYVnMgtNxiMUhTJO780wonZUzJrPQTLYI0erSIMZF8cniWFW22kGQUECd8rdHRJ/ZJL2XO54c9Ttuw==
   dependencies:
     use-sync-external-store "1.2.0"


### PR DESCRIPTION
Pins Zustand to `4.2.x` since `4.3.0` introduced a breaking change, removing the default export (https://github.com/pmndrs/zustand/pull/1514). Will need to investigate the effects of https://github.com/pmndrs/zustand/pull/1531 since it does not appear sufficient.