### PR TITLE
refactor(types)!: support for OGL v1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "expo-gl": "~11.4.0",
     "jest": "^28.1.3",
     "jest-environment-jsdom": "^28.1.3",
-    "ogl": "^0.0.97",
+    "ogl": "^1.0.3",
     "prettier": "^2.7.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
@@ -55,19 +55,18 @@
     "vite": "^3.0.9"
   },
   "dependencies": {
-    "@types/ogl": "npm:ogl-types@^0.0.99",
     "@types/react-reconciler": "^0.26.7",
-    "@types/webxr": "^0.5.0",
-    "its-fine": "^1.0.5",
+    "@types/webxr": "*",
+    "its-fine": "^1.1.1",
     "react-reconciler": "^0.27.0",
     "react-use-measure": "^2.1.1",
     "scheduler": "^0.23.0",
-    "suspend-react": "^0.0.8",
+    "suspend-react": "^0.1.3",
     "zustand": "^4.1.2"
   },
   "peerDependencies": {
     "expo-gl": ">=11.4",
-    "ogl": ">=0.0.97",
+    "ogl": ">=1",
     "react": ">=18.0",
     "react-dom": ">=18.0",
     "react-native": ">=0.69"

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -71,9 +71,12 @@ export function useGraph(object: OGL.Transform) {
     object.traverse((obj: OGL.Transform | OGL.Mesh) => {
       if (!(obj instanceof OGL.Mesh)) return
 
+      // @ts-ignore
       if (obj.name) data.nodes[obj.name] = obj
 
+      // @ts-ignore
       if (obj.program.gltfMaterial && !data.programs[obj.program.gltfMaterial.name]) {
+        // @ts-ignore
         data.programs[obj.program.gltfMaterial.name] = obj.program
       }
     })
@@ -128,7 +131,7 @@ export function useLoader<L extends LoaderRepresentation, I extends string | str
         urls.map(async (url: string) => {
           // @ts-ignore OGL's loaders don't have a consistent signature
           if (classExtends(loader, OGL.TextureLoader)) return loader.load(gl, { src: url })
-
+          // @ts-ignore
           return await loader.load(gl, url)
         }),
       )

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -100,7 +100,7 @@ export function render(
         },
         events,
         mouse: new OGL.Vec2(),
-        raycaster: new OGL.Raycast(gl),
+        raycaster: new OGL.Raycast(),
         hovered: new Map(),
         set,
         get,

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react'
+import * as OGL from 'ogl'
 import create from 'zustand'
 import { render } from './utils'
 import { act, OGLContext, useOGL, useFrame, RootState, Subscription, Instance, useInstanceHandle } from '../src'

--- a/yarn.lock
+++ b/yarn.lock
@@ -1582,11 +1582,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.13.tgz#23e6c5168333480d454243378b69e861ab5c011a"
   integrity sha512-46yIhxSe5xEaJZXWdIBP7GU4HDTG8/eo0qd9atdiL+lFpA03y8KS+lkTN834TWJj5767GbWv4n/P6efyTFt1Dw==
 
-"@types/ogl@npm:ogl-types@^0.0.99":
-  version "0.0.99"
-  resolved "https://registry.yarnpkg.com/ogl-types/-/ogl-types-0.0.99.tgz#495d38fc3323cb61882daca9e8084e4693cd0f47"
-  integrity sha512-pY1+0VTIIAMGtiBzn4LBy+wjgQv0Nf7BEeE1XGnjvPKS9QhhWwWW+Ys6BnKCiQZgaNPbYeHBg5ln2J9bQEnWCA==
-
 "@types/parse5@^6.0.3":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@types/parse5/-/parse5-6.0.3.tgz#705bb349e789efa06f43f128cef51240753424cb"
@@ -1654,10 +1649,10 @@
   resolved "https://registry.yarnpkg.com/@types/tough-cookie/-/tough-cookie-4.0.2.tgz#6286b4c7228d58ab7866d19716f3696e03a09397"
   integrity sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==
 
-"@types/webxr@^0.5.0":
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.5.0.tgz#aae1cef3210d88fd4204f8c33385a0bbc4da07c9"
-  integrity sha512-IUMDPSXnYIbEO2IereEFcgcqfDREOgmbGqtrMpVPpACTU6pltYLwHgVkrnYv0XhWEcjio9sYEfIEzgn3c7nDqA==
+"@types/webxr@*":
+  version "0.5.7"
+  resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.5.7.tgz#7a3aaaf1ceeaaad13f1dda66d6571852405bb221"
+  integrity sha512-Rcgs5c2eNFnHp53YOjgtKfl/zWX1Y+uFGUwlSXrWcZWu3yhANRezmph4MninmqybUYT6g9ZE0aQ9QIdPkLR3Kg==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -4190,10 +4185,10 @@ istanbul-reports@^3.1.3:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-its-fine@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.0.5.tgz#dbd8130e021aafe030ca5001085c27ff2a057ab3"
-  integrity sha512-JVqIHuUGRF4mBJWV/o9CS86wU57oWAX+mE2iokFpZ+B1R1tcfRvLZXVFd9tWJgY7gfhBURYyXJs7LcoJl/Af+Q==
+its-fine@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.1.1.tgz#e74b93fddd487441f978a50f64f0f5af4d2fc38e"
+  integrity sha512-v1Ia1xl20KbuSGlwoaGsW0oxsw8Be+TrXweidxD9oT/1lAh6O3K3/GIM95Tt6WCiv6W+h2M7RB1TwdoAjQyyKw==
   dependencies:
     "@types/react-reconciler" "^0.28.0"
 
@@ -5538,10 +5533,10 @@ object.values@^1.1.5:
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
 
-ogl@^0.0.97:
-  version "0.0.97"
-  resolved "https://registry.yarnpkg.com/ogl/-/ogl-0.0.97.tgz#88d71846599e1c81f96825562162582e5f6d6ab6"
-  integrity sha512-8VGNwb+BnVgg80uF2MDJGX+rLja8DPvmSsW1a3KCZO4pQF8sszRCgQVQmUA2EnoIYXtMUEztChkB0fuoFcWLxw==
+ogl@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/ogl/-/ogl-1.0.3.tgz#e8812e9673ece650df68f59976039dae35696dc0"
+  integrity sha512-MOpTaRVZB5ekoBbLp3ANLQVxm9/QgREkwT0/O+tkc73ElIOAxedUFv+F6vSfVtG1m5TuYKaTUsFexXvCkHuhSw==
 
 on-finished@2.4.1:
   version "2.4.1"
@@ -6741,10 +6736,10 @@ supports-preserve-symlinks-flag@^1.0.0:
   resolved "https://registry.yarnpkg.com/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz#6eda4bd344a3c94aea376d4cc31bc77311039e09"
   integrity sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==
 
-suspend-react@^0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/suspend-react/-/suspend-react-0.0.8.tgz#b0740c1386b4eb652f17affe4339915ee268bd31"
-  integrity sha512-ZC3r8Hu1y0dIThzsGw0RLZplnX9yXwfItcvaIzJc2VQVi8TGyGDlu92syMB5ulybfvGLHAI5Ghzlk23UBPF8xg==
+suspend-react@^0.1.3:
+  version "0.1.3"
+  resolved "https://registry.yarnpkg.com/suspend-react/-/suspend-react-0.1.3.tgz#a52f49d21cfae9a2fb70bd0c68413d3f9d90768e"
+  integrity sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==
 
 symbol-tree@^3.2.4:
   version "3.2.4"


### PR DESCRIPTION
Adds support for https://github.com/oframe/ogl/pull/188, drops https://github.com/CodyJasonBennett/ogl-types via `@types/ogl`.