### PR TITLE
feat: update Zustand to use latest API

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "react-use-measure": "^2.1.1",
     "scheduler": "^0.23.0",
     "suspend-react": "^0.1.3",
-    "zustand": "^4.1.2"
+    "zustand": "^4.5.2"
   },
   "peerDependencies": {
     "expo-gl": ">=11.4",

--- a/src/renderer.tsx
+++ b/src/renderer.tsx
@@ -1,7 +1,7 @@
 import * as OGL from 'ogl'
 import * as React from 'react'
 import { ConcurrentRoot } from 'react-reconciler/constants.js'
-import create from 'zustand'
+import { create } from 'zustand'
 import { reconciler } from './reconciler'
 import { OGLContext, useStore, useIsomorphicLayoutEffect } from './hooks'
 import { RenderProps, Root, RootState, RootStore, Subscription } from './types'

--- a/tests/hooks.test.tsx
+++ b/tests/hooks.test.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import * as OGL from 'ogl'
-import create from 'zustand'
+import { create } from 'zustand'
 import { render } from './utils'
 import { act, OGLContext, useOGL, useFrame, RootState, Subscription, Instance, useInstanceHandle } from '../src'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7343,9 +7343,9 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zustand@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.1.2.tgz#4912b24741662d8a84ed1cb52198471cb369c4b6"
-  integrity sha512-gcRaKchcxFPbImrBb/BKgujOhHhik9YhVpIeP87ETT7uokEe2Szu7KkuZ9ghjtD+/KKkcrRNktR2AiLXPIbKIQ==
+zustand@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/zustand/-/zustand-4.5.2.tgz#fddbe7cac1e71d45413b3682cdb47b48034c3848"
+  integrity sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==
   dependencies:
     use-sync-external-store "1.2.0"


### PR DESCRIPTION
When using a custom renderer, the following warning appears:

<img width="506" alt="Screenshot 2024-03-08 at 1 47 28 PM" src="https://github.com/pmndrs/react-ogl/assets/29680544/2b56ee7e-5cae-4682-a90b-41381b742e73">

This PR fixes the issue by updating Zustand to the latest version.