### PR TITLE
Fix ```unstable_act``` error

### DIFF
--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -454,7 +454,7 @@ export const reconciler = Reconciler<
 /**
  * Safely flush async effects when testing, simulating a legacy root.
  */
-export const act: Act = (React as any)?.unstable_act
+export const act: Act = (React as any)?.unstable_act ?? (React as any)?.act
 
 // Inject renderer meta into devtools
 const isProd = typeof process === 'undefined' || process.env?.['NODE_ENV'] === 'production'

--- a/src/reconciler.ts
+++ b/src/reconciler.ts
@@ -454,7 +454,7 @@ export const reconciler = Reconciler<
 /**
  * Safely flush async effects when testing, simulating a legacy root.
  */
-export const act: Act = (React as any).unstable_act
+export const act: Act = (React as any)?.unstable_act
 
 // Inject renderer meta into devtools
 const isProd = typeof process === 'undefined' || process.env?.['NODE_ENV'] === 'production'


### PR DESCRIPTION
I faced this error using nextjs on react 18. Adding the optional chaining operator seems to fix it.

```
"next": "14.2.3",
"react": "18.3.1",
```

![image](https://github.com/pmndrs/react-ogl/assets/43894343/ab854762-fa84-414f-b507-6a309c37b1d6)