### PR TITLE
fix(types): resolve annotations with bundler resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,19 @@
   "license": "MIT",
   "types": "./dist/index.d.ts",
   "module": "./dist/index.mjs",
-  "exports": "./dist/index.mjs",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "react-native": {
+        "types": "./dist/index.native.d.ts",
+        "import": "./dist/index.native.mjs"
+      },
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.mjs"
+      }
+    }
+  },
   "react-native": "./dist/index.native.mjs",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
Fixes #85 where ESM types cannot be resolved with Node 16 or bundler resolution.